### PR TITLE
docs: add ARCHITECTURE.md with layering and import rules

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,18 +1,18 @@
 # Architecture Overview
 
-Layers
+## Layers
 - Domain: pure business logic, no infra dependencies.
 - Application (Use-cases): orchestrates domain operations, transforms input/out.
 - Adapters: translate between application and infrastructure (DB, HTTP clients).
 - Infrastructure: concrete implementations (DB clients, external APIs, message brokers).
 
-Import rules
+## Import rules
 - Domain <- no imports from other layers
 - Application <- may import Domain
 - Adapters <- may import Application & Domain
 - Infrastructure <- may import Adapters
 - No cyclical imports. Prefer dependency injection to pass infra clients into adapters.
 
-Quick checklist
+## Quick checklist
 - Files that do DB/HTTP + business logic in same file should be split.
 - Avoid module-level mutable state; use explicit state objects.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,18 @@
+# Architecture Overview
+
+Layers
+- Domain: pure business logic, no infra dependencies.
+- Application (Use-cases): orchestrates domain operations, transforms input/out.
+- Adapters: translate between application and infrastructure (DB, HTTP clients).
+- Infrastructure: concrete implementations (DB clients, external APIs, message brokers).
+
+Import rules
+- Domain <- no imports from other layers
+- Application <- may import Domain
+- Adapters <- may import Application & Domain
+- Infrastructure <- may import Adapters
+- No cyclical imports. Prefer dependency injection to pass infra clients into adapters.
+
+Quick checklist
+- Files that do DB/HTTP + business logic in same file should be split.
+- Avoid module-level mutable state; use explicit state objects.


### PR DESCRIPTION
Adds an ARCHITECTURE.md documenting layers, import rules, and quick checklist to reduce coupling and clarify module ownership.