### PR TITLE
refactor: improve rust backend initialization error handling

### DIFF
--- a/src/core/execution/request-execution-manager.ts
+++ b/src/core/execution/request-execution-manager.ts
@@ -15,7 +15,10 @@ import { logger } from '../logger.js';
 import { getErrorMessage, toError } from '../../utils/error-utils.js';
 import { ModelRequest, ModelResponse } from '../../domain/interfaces/model-client.js';
 import { ProjectContext, ComplexityAnalysis, TaskType } from '../../domain/types/unified-types.js';
-import { ActiveProcess, ActiveProcessManager } from '../../infrastructure/performance/active-process-manager.js';
+import {
+  ActiveProcess,
+  ActiveProcessManager,
+} from '../../infrastructure/performance/active-process-manager.js';
 import {
   EnhancedToolIntegration,
   getGlobalEnhancedToolIntegration,
@@ -181,13 +184,19 @@ export class RequestExecutionManager extends EventEmitter implements IRequestExe
 
   private async initializeRustBackend(): Promise<void> {
     try {
-      await this.rustBackend.initialize();
-      logger.info('🚀 RequestExecutionManager: Rust backend initialized', {
-        available: this.rustBackend.isAvailable(),
-        strategy: this.rustBackend.getStrategy(),
-      });
+      const initialized = await this.rustBackend.initialize();
+      if (initialized) {
+        logger.info('🚀 RequestExecutionManager: Rust backend initialized', {
+          available: this.rustBackend.isAvailable(),
+          strategy: this.rustBackend.getStrategy(),
+        });
+      } else {
+        logger.warn(
+          '⚠️ RequestExecutionManager: Rust backend module not found, using TypeScript fallback'
+        );
+      }
     } catch (error) {
-      logger.warn('⚠️ RequestExecutionManager: Rust backend initialization failed, using TypeScript fallback:', error);
+      logger.error('❌ RequestExecutionManager: Rust backend initialization failed', error);
     }
   }
 

--- a/src/core/execution/rust-executor/rust-bridge-manager.ts
+++ b/src/core/execution/rust-executor/rust-bridge-manager.ts
@@ -68,12 +68,7 @@ export class RustBridgeManager {
 
       this.rustModule = await Promise.race([loadPromise, timeoutPromise]);
 
-      if (!this.rustModule) {
-        logger.warn('Rust bridge module not found', {
-          modulePath: this.config.modulePath,
-        });
-        this.health.status = 'failed';
-        return false;
+        throw new Error('Rust bridge module not found');
       }
 
       this.health.status = 'healthy';

--- a/src/core/execution/rust-executor/rust-bridge-manager.ts
+++ b/src/core/execution/rust-executor/rust-bridge-manager.ts
@@ -1,6 +1,6 @@
 /**
  * Rust Bridge Manager - Phase 4 Implementation
- * 
+ *
  * Manages the NAPI bridge between TypeScript and Rust, handling
  * module loading, lifecycle management, and communication protocols.
  */
@@ -60,25 +60,32 @@ export class RustBridgeManager {
       // Load the native module with timeout
       const loadPromise = this.loadRustModule();
       const timeoutPromise = new Promise((_, reject) =>
-        setTimeout(() => reject(new Error('Module load timeout')), this.config.initializationTimeout)
+        setTimeout(
+          () => reject(new Error('Module load timeout')),
+          this.config.initializationTimeout
+        )
       );
 
       this.rustModule = await Promise.race([loadPromise, timeoutPromise]);
 
-      if (this.rustModule) {
-        this.health.status = 'healthy';
-        this.startHealthMonitoring();
-        
-        logger.info('Rust bridge initialized successfully');
-        return true;
+      if (!this.rustModule) {
+        logger.warn('Rust bridge module not found', {
+          modulePath: this.config.modulePath,
+        });
+        this.health.status = 'failed';
+        return false;
       }
 
-      return false;
+      this.health.status = 'healthy';
+      this.startHealthMonitoring();
+
+      logger.info('Rust bridge initialized successfully');
+      return true;
     } catch (error) {
       logger.error('Failed to initialize Rust bridge:', error);
       this.health.status = 'failed';
       this.health.errorCount++;
-      return false;
+      throw error;
     }
   }
 
@@ -117,10 +124,10 @@ export class RustBridgeManager {
 
     try {
       const startTime = Date.now();
-      
+
       // Test basic functionality
       const testResult = this.rustModule.add(2, 2);
-      
+
       this.health.responseTime = Date.now() - startTime;
       this.health.lastCheck = new Date();
 
@@ -137,13 +144,13 @@ export class RustBridgeManager {
       this.health.status = 'failed';
       this.health.errorCount++;
       this.health.lastCheck = new Date();
-      
+
       // Auto-recovery attempt
       if (this.config.autoRecover && this.health.errorCount < 5) {
         logger.info('Attempting Rust bridge recovery...');
         return this.initialize();
       }
-      
+
       return false;
     }
   }
@@ -160,7 +167,7 @@ export class RustBridgeManager {
 
       this.rustModule = null;
       this.health.status = 'failed';
-      
+
       logger.info('Rust bridge shut down successfully');
     } catch (error) {
       logger.error('Error during Rust bridge shutdown:', error);

--- a/src/core/execution/rust-executor/rust-execution-backend.ts
+++ b/src/core/execution/rust-executor/rust-execution-backend.ts
@@ -87,7 +87,7 @@ export class RustExecutionBackend {
   /**
    * Initialize the Rust executor NAPI module
    */
-  async initialize(): Promise<boolean> {
+  async initialize(): Promise<void> {
     try {
       // Initialize logging for Rust module
       if (typeof global !== 'undefined') {

--- a/src/core/execution/rust-executor/rust-execution-backend.ts
+++ b/src/core/execution/rust-executor/rust-execution-backend.ts
@@ -155,9 +155,7 @@ export class RustExecutionBackend {
         return true;
       }
 
-      logger.warn('⚠️ Rust module not found or invalid');
-      this.initialized = false;
-      return false;
+      throw new Error('Rust module not found or invalid');
     } catch (error) {
       logger.error('RustExecutionBackend initialization error:', error);
       this.initialized = false;

--- a/src/core/execution/rust-executor/rust-execution-backend.ts
+++ b/src/core/execution/rust-executor/rust-execution-backend.ts
@@ -1,6 +1,6 @@
 /**
  * Rust Execution Backend - Production Implementation
- * 
+ *
  * Integrates the complete Rust executor with comprehensive security, performance,
  * and tool execution capabilities. Replaces TypeScript executors with blazing-fast Rust.
  */
@@ -8,7 +8,10 @@
 import { logger } from '../../logger.js';
 import path from 'path';
 import { pathToFileURL } from 'url';
-import type { ToolExecutionRequest, ToolExecutionResult } from '../../../domain/interfaces/tool-system.js';
+import type {
+  ToolExecutionRequest,
+  ToolExecutionResult,
+} from '../../../domain/interfaces/tool-system.js';
 import { ModelRequest, ModelResponse } from '../../../domain/interfaces/model-client.js';
 import { ProjectContext } from '../../../domain/types/unified-types.js';
 
@@ -39,7 +42,12 @@ export interface RustExecutionResult {
 // Import the actual NAPI module types
 interface NativeRustExecutor {
   initialize(): Promise<boolean>;
-  executeFilesystem(operation: string, path: string, content?: string, options?: any): Promise<RustExecutionResult>;
+  executeFilesystem(
+    operation: string,
+    path: string,
+    content?: string,
+    options?: any
+  ): Promise<RustExecutionResult>;
   executeCommand(command: string, args: string[], options?: any): Promise<RustExecutionResult>;
   execute(toolId: string, args: string, options?: any): Promise<RustExecutionResult>;
   getPerformanceMetrics(): Promise<string>;
@@ -79,7 +87,7 @@ export class RustExecutionBackend {
   /**
    * Initialize the Rust executor NAPI module
    */
-  async initialize(): Promise<void> {
+  async initialize(): Promise<boolean> {
     try {
       // Initialize logging for Rust module
       if (typeof global !== 'undefined') {
@@ -97,7 +105,7 @@ export class RustExecutionBackend {
             return {};
           }
         });
-        
+
         if (initLogging) {
           await initLogging(this.options.logLevel);
           logger.info('🚀 Rust executor logging initialized');
@@ -105,43 +113,55 @@ export class RustExecutionBackend {
       }
 
       // Load the Rust executor NAPI module
-      const { RustExecutor, createRustExecutor } = await import('./rust-native-module.js').catch(async () => {
-        try {
-          // Try the NAPI module name from package.json
-          const napiModule = await import('codecrucible-rust-executor' as any).catch(() => {
-            // Try direct build output path
-            const directPath = path.join(process.cwd(), 'rust-executor.node');
-            return import(directPath);
-          });
-          return napiModule;
-        } catch {
-          // Return empty module as fallback
-          return {};
+      const { RustExecutor, createRustExecutor } = await import('./rust-native-module.js').catch(
+        async () => {
+          try {
+            // Try the NAPI module name from package.json
+            const napiModule = await import('codecrucible-rust-executor' as any).catch(() => {
+              // Try direct build output path
+              const directPath = path.join(process.cwd(), 'rust-executor.node');
+              return import(directPath);
+            });
+            return napiModule;
+          } catch {
+            // Return empty module as fallback
+            return {};
+          }
         }
-      });
-      
+      );
+
       if (RustExecutor || createRustExecutor) {
         this.rustExecutor = RustExecutor ? RustExecutor.create() : createRustExecutor();
-        
-        // Initialize the Rust executor
-        const initResult = await this.rustExecutor.initialize();
-        if (initResult) {
-          this.initialized = true;
-          logger.info('🚀 RustExecutionBackend initialized successfully', {
-            executorId: this.rustExecutor.getId(),
-            supportedTools: this.rustExecutor.getSupportedTools(),
-            performanceMetrics: this.options.enableProfiling,
-          });
-        } else {
-          throw new Error('Rust executor initialization failed');
+
+        try {
+          const initResult = await this.rustExecutor.initialize();
+          if (!initResult) {
+            logger.error('❌ Rust executor initialization failed');
+            this.initialized = false;
+            throw new Error('Rust executor initialization failed');
+          }
+        } catch (error) {
+          logger.error('❌ Rust executor initialization threw error:', error);
+          this.initialized = false;
+          throw error;
         }
-      } else {
-        throw new Error('Rust module not found or invalid');
+
+        this.initialized = true;
+        logger.info('🚀 RustExecutionBackend initialized successfully', {
+          executorId: this.rustExecutor.getId(),
+          supportedTools: this.rustExecutor.getSupportedTools(),
+          performanceMetrics: this.options.enableProfiling,
+        });
+        return true;
       }
-    } catch (error) {
-      logger.warn('⚠️ Rust executor not available, using fallback mode:', error);
-      // Set flag for fallback mode but don't throw - graceful degradation
+
+      logger.warn('⚠️ Rust module not found or invalid');
       this.initialized = false;
+      return false;
+    } catch (error) {
+      logger.error('RustExecutionBackend initialization error:', error);
+      this.initialized = false;
+      throw error;
     }
   }
 
@@ -161,12 +181,12 @@ export class RustExecutionBackend {
     try {
       // Determine execution strategy based on request
       let result: RustExecutionResult;
-      
+
       if (request.toolId === 'filesystem' || request.toolId?.startsWith('file')) {
         // File system operations
         result = await this.executeFilesystemOperation(request);
       } else if (request.toolId === 'command' || request.toolId?.startsWith('cmd')) {
-        // Command operations  
+        // Command operations
         result = await this.executeCommandOperation(request);
       } else {
         // Generic tool execution
@@ -186,10 +206,12 @@ export class RustExecutionBackend {
       return {
         success: result.success,
         result: result.result,
-        error: result.error ? {
-          code: 'RUST_EXECUTION_ERROR',
-          message: result.error,
-        } : undefined,
+        error: result.error
+          ? {
+              code: 'RUST_EXECUTION_ERROR',
+              message: result.error,
+            }
+          : undefined,
         metadata: {
           executionTimeMs: result.execution_time_ms,
           executor: 'rust',
@@ -201,7 +223,7 @@ export class RustExecutionBackend {
     } catch (error) {
       this.performanceStats.failedRequests++;
       logger.error('Rust execution failed:', error);
-      
+
       return {
         success: false,
         result: undefined,
@@ -252,10 +274,12 @@ export class RustExecutionBackend {
 
   // Private helper methods
 
-  private async executeTypescriptFallback(request: ToolExecutionRequest): Promise<ToolExecutionResult> {
+  private async executeTypescriptFallback(
+    request: ToolExecutionRequest
+  ): Promise<ToolExecutionResult> {
     const startTime = Date.now();
     this.performanceStats.totalRequests++;
-    
+
     try {
       // Basic TypeScript fallback - could integrate with existing TypeScript executors
       const result = {
@@ -266,7 +290,7 @@ export class RustExecutionBackend {
 
       this.performanceStats.successfulRequests++;
       this.updateAverageExecutionTime(Date.now() - startTime);
-      
+
       return {
         success: true,
         result: result,
@@ -280,7 +304,7 @@ export class RustExecutionBackend {
       };
     } catch (error) {
       this.performanceStats.failedRequests++;
-      
+
       return {
         success: false,
         result: undefined,
@@ -313,15 +337,17 @@ export class RustExecutionBackend {
   private extractCapabilities(request: ToolExecutionRequest): string[] {
     // Extract capabilities from request context or permissions
     const capabilities: string[] = [];
-    
+
     if (request.context?.permissions) {
       capabilities.push(...request.context.permissions.map(p => `${p.type}:${p.resource}`));
     }
-    
+
     return capabilities;
   }
 
-  private async executeFilesystemOperation(request: ToolExecutionRequest): Promise<RustExecutionResult> {
+  private async executeFilesystemOperation(
+    request: ToolExecutionRequest
+  ): Promise<RustExecutionResult> {
     if (!this.rustExecutor) {
       throw new Error('Rust executor not initialized');
     }
@@ -338,7 +364,9 @@ export class RustExecutionBackend {
     return await this.rustExecutor.executeFilesystem(operation, path, content, options);
   }
 
-  private async executeCommandOperation(request: ToolExecutionRequest): Promise<RustExecutionResult> {
+  private async executeCommandOperation(
+    request: ToolExecutionRequest
+  ): Promise<RustExecutionResult> {
     if (!this.rustExecutor) {
       throw new Error('Rust executor not initialized');
     }
@@ -356,7 +384,9 @@ export class RustExecutionBackend {
     return await this.rustExecutor.executeCommand(command, args, options);
   }
 
-  private async executeGenericOperation(request: ToolExecutionRequest): Promise<RustExecutionResult> {
+  private async executeGenericOperation(
+    request: ToolExecutionRequest
+  ): Promise<RustExecutionResult> {
     if (!this.rustExecutor) {
       throw new Error('Rust executor not initialized');
     }
@@ -375,8 +405,10 @@ export class RustExecutionBackend {
   }
 
   private updateAverageExecutionTime(executionTime: number): void {
-    const totalTime = this.performanceStats.averageExecutionTime * this.performanceStats.successfulRequests;
-    this.performanceStats.averageExecutionTime = (totalTime + executionTime) / (this.performanceStats.successfulRequests + 1);
+    const totalTime =
+      this.performanceStats.averageExecutionTime * this.performanceStats.successfulRequests;
+    this.performanceStats.averageExecutionTime =
+      (totalTime + executionTime) / (this.performanceStats.successfulRequests + 1);
   }
 
   /**


### PR DESCRIPTION
## Summary
- log clearer messages when the Rust module is missing vs. when initialization fails
- propagate critical Rust backend initialization errors so callers can fall back explicitly

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck` *(fails: Cannot find type definition file for '@types/node')*
- `npm test` *(fails: Cannot find module 'jest' `node_modules/jest/bin/jest.js`)*

------
https://chatgpt.com/codex/tasks/task_e_68b5703cb764832db8175067d4cd3cce