### PR TITLE
fix(core): add disposers for timers

### DIFF
--- a/src/core/intelligence/lazy-project-intelligence.ts
+++ b/src/core/intelligence/lazy-project-intelligence.ts
@@ -58,7 +58,6 @@ export class LazyProjectIntelligenceSystem extends EventEmitter {
 
     // Cleanup timer to prevent memory leaks
     this.cleanupInterval = setInterval(() => this.cleanupCache(), 300000); // 5 minutes
-    // TODO: Store interval ID and call clearInterval in cleanup
   }
 
   /**
@@ -378,6 +377,10 @@ export class LazyProjectIntelligenceSystem extends EventEmitter {
     }
     await this.clearCache();
     this.removeAllListeners();
+  }
+
+  async dispose(): Promise<void> {
+    await this.shutdown();
   }
 }
 

--- a/src/core/intelligence/lazy-project-intelligence.ts
+++ b/src/core/intelligence/lazy-project-intelligence.ts
@@ -380,6 +380,10 @@ export class LazyProjectIntelligenceSystem extends EventEmitter {
   }
 
   async dispose(): Promise<void> {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+      this.cleanupInterval = undefined;
+    }
     await this.shutdown();
   }
 }

--- a/tests/unit/core/intelligence/lazy-project-intelligence-system.test.ts
+++ b/tests/unit/core/intelligence/lazy-project-intelligence-system.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { LazyProjectIntelligenceSystem } from '../../../../src/core/intelligence/lazy-project-intelligence.js';
+
+describe('LazyProjectIntelligenceSystem cleanup', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('clears cleanup interval on dispose', async () => {
+    const before = jest.getTimerCount();
+    const system = new LazyProjectIntelligenceSystem();
+    expect(jest.getTimerCount()).toBeGreaterThan(before);
+    await system.dispose();
+    expect(jest.getTimerCount()).toBe(before);
+  });
+});

--- a/tests/unit/infrastructure/tools/enhanced-tool-integration.test.ts
+++ b/tests/unit/infrastructure/tools/enhanced-tool-integration.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { EnhancedToolIntegration } from '../../../../src/infrastructure/tools/enhanced-tool-integration.js';
+
+describe('EnhancedToolIntegration cleanup', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('clears cache cleanup interval on dispose', () => {
+    const before = jest.getTimerCount();
+    const integration = new EnhancedToolIntegration();
+    expect(jest.getTimerCount()).toBeGreaterThan(before);
+    integration.dispose();
+    expect(jest.getTimerCount()).toBe(before);
+  });
+});


### PR DESCRIPTION
## Summary
- capture cache cleanup interval in EnhancedToolIntegration and add dispose
- track process/coordinator listeners in UnifiedCLI with cleanup on dispose
- expose dispose on LazyProjectIntelligenceSystem for cleanup
- add tests ensuring timer cleanup after teardown

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run format`
- `npm run typecheck` *(fails: Cannot find type definition file for '@types/node')*
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b57043e538832d8715a92b9aee8dd0