### PR TITLE
feat(observability): add telemetry metrics and interval cleanup

### DIFF
--- a/src/core/application/synthesis-coordinator.ts
+++ b/src/core/application/synthesis-coordinator.ts
@@ -28,6 +28,8 @@ import {
   PERFORMANCE_MONITOR_TOKEN,
 } from '../di/service-tokens.js';
 import { logger } from '../logger.js';
+import * as os from 'os';
+import { getTelemetryProvider } from '../observability/observability-system.js';
 import {
   ModelRequest,
   ModelResponse,
@@ -101,6 +103,7 @@ export class SynthesisCoordinator extends EventEmitter {
   private container: DependencyContainer;
   private initialized = false;
   private startTime: number;
+  private telemetry = getTelemetryProvider();
 
   constructor(container: DependencyContainer) {
     super();
@@ -212,6 +215,28 @@ export class SynthesisCoordinator extends EventEmitter {
     startTime: number
   ): Promise<ApplicationResponse> {
     const processingTime = Date.now() - startTime;
+    const totalTokens = modelResponse.tokens_used || modelResponse.metadata?.tokens || 0;
+    let cacheHitRate = 0;
+    try {
+      const cacheCoordinator = this.container.resolve(CACHE_COORDINATOR_TOKEN);
+      const cacheStats = await cacheCoordinator.getCacheStats();
+      const hit = cacheStats.hitRate || 0;
+      cacheHitRate = typeof hit === 'string' ? parseFloat(hit) / 100 : hit / 100;
+      this.telemetry.recordMetric(
+        'cache_hit_rate',
+        cacheHitRate * 100,
+        { component: 'synthesis' },
+        '%'
+      );
+    } catch {
+      cacheHitRate = 0;
+    }
+    const cpuUsage = this.getCpuUsage();
+    const memoryUsage = this.getMemoryUsage();
+    const costEstimate = this.estimateCost(totalTokens);
+    this.telemetry.recordMetric('cpu_usage', cpuUsage, { component: 'synthesis' }, '%');
+    this.telemetry.recordMetric('memory_usage', memoryUsage, { component: 'synthesis' }, 'MB');
+    this.telemetry.recordMetric('cost_estimate', costEstimate, { component: 'synthesis' }, 'usd');
 
     // Enhanced synthesis response
     return {
@@ -240,11 +265,11 @@ export class SynthesisCoordinator extends EventEmitter {
         processingTime,
         voicesConsulted: 1,
         modelsUsed: [modelResponse.model || 'unknown'],
-        totalTokens: modelResponse.tokens_used || modelResponse.metadata?.tokens || 0,
+        totalTokens,
         cachingUsed: modelResponse.cached || false,
         ragUsed: false, // TODO: Implement when RAG is integrated
         workflowUsed: false, // TODO: Implement when workflows are integrated
-        costEstimate: 0, // TODO: Implement cost calculation
+        costEstimate,
       },
       quality: {
         overall: 0.8,
@@ -256,10 +281,10 @@ export class SynthesisCoordinator extends EventEmitter {
       performance: {
         responseTime: processingTime,
         tokenRate: this.calculateTokenRate(modelResponse, processingTime),
-        cacheHitRate: 0.0, // TODO: Get from cache coordinator
+        cacheHitRate,
         resourceUsage: {
-          memory: this.getMemoryUsage(),
-          cpu: 0.0, // TODO: Implement CPU monitoring
+          memory: memoryUsage,
+          cpu: cpuUsage,
         },
       },
     };
@@ -393,6 +418,20 @@ export class SynthesisCoordinator extends EventEmitter {
     } catch (error) {
       return 0;
     }
+  }
+
+  private getCpuUsage(): number {
+    try {
+      const loads = os.loadavg();
+      const cores = os.cpus().length || 1;
+      return (loads[0] / cores) * 100;
+    } catch {
+      return 0;
+    }
+  }
+
+  private estimateCost(tokens: number): number {
+    return tokens * 0.0001;
   }
 
   /**

--- a/tests/unit/application/synthesis-coordinator-telemetry.test.ts
+++ b/tests/unit/application/synthesis-coordinator-telemetry.test.ts
@@ -1,0 +1,64 @@
+import { SynthesisCoordinator } from '../../../src/core/application/synthesis-coordinator.js';
+import { DependencyContainer } from '../../../src/core/di/dependency-container.js';
+import {
+  CLIENT_TOKEN,
+  CACHE_COORDINATOR_TOKEN,
+  SECURITY_VALIDATOR_TOKEN,
+  PERFORMANCE_MONITOR_TOKEN,
+  HYBRID_ROUTER_TOKEN,
+  STREAMING_MANAGER_TOKEN,
+} from '../../../src/core/di/service-tokens.js';
+
+const recordMetric = jest.fn();
+
+jest.mock('../../../src/core/observability/observability-system.ts', () => ({
+  getTelemetryProvider: () => ({ recordMetric }),
+}));
+
+describe('SynthesisCoordinator telemetry', () => {
+  it('records resource metrics during request processing', async () => {
+    const container = new DependencyContainer();
+    container.registerValue(SECURITY_VALIDATOR_TOKEN, {
+      validateRequest: async () => ({ isValid: true }),
+    });
+    container.registerValue(CLIENT_TOKEN, {
+      synthesize: async () => ({ content: 'ok', tokens_used: 10, cached: true }),
+    });
+    container.registerValue(CACHE_COORDINATOR_TOKEN, {
+      getCacheStats: async () => ({ hitRate: 50 }),
+    });
+    container.registerValue(PERFORMANCE_MONITOR_TOKEN, {
+      recordRequest: jest.fn(),
+    });
+    container.registerValue(HYBRID_ROUTER_TOKEN, {});
+    container.registerValue(STREAMING_MANAGER_TOKEN, {});
+
+    const coordinator = new SynthesisCoordinator(container);
+    await coordinator.processRequest({ prompt: 'hello world' });
+
+    expect(recordMetric).toHaveBeenCalledWith(
+      'cpu_usage',
+      expect.any(Number),
+      { component: 'synthesis' },
+      '%'
+    );
+    expect(recordMetric).toHaveBeenCalledWith(
+      'memory_usage',
+      expect.any(Number),
+      { component: 'synthesis' },
+      'MB'
+    );
+    expect(recordMetric).toHaveBeenCalledWith(
+      'cache_hit_rate',
+      expect.any(Number),
+      { component: 'synthesis' },
+      '%'
+    );
+    expect(recordMetric).toHaveBeenCalledWith(
+      'cost_estimate',
+      expect.any(Number),
+      { component: 'synthesis' },
+      'usd'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- track cache hit rate, cost estimates, CPU and memory usage in SynthesisCoordinator via telemetry
- register and clear monitoring intervals across performance optimizers
- add unit test ensuring telemetry metrics are emitted during requests

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run format`
- `npm run typecheck`
- `npm test` *(fails: Cannot find module ../../../../src/core/agents/agent-communication-protocol.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b5704f5268832d87d3137198304e52