### PR TITLE
feat(rust-executor): enforce resource limits for spawned commands

### DIFF
--- a/rust-executor/Cargo.toml
+++ b/rust-executor/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0"
 
 # Cross-platform process management
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.27", features = ["process", "signal", "user", "fs"] }
+nix = { version = "0.27", features = ["process", "signal", "user", "fs", "resource"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["processthreadsapi", "jobapi", "jobapi2", "handleapi", "winbase", "errhandlingapi"] }


### PR DESCRIPTION
## Summary
- add memory limit field to `CommandExecutor`
- apply Unix `setrlimit` in spawned processes for memory and CPU

## Testing
- `cargo test` *(fails: could not compile `codecrucible-rust-executor` ...)*
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run format`
- `npm run typecheck` *(fails: Cannot find type definition file for '@types/node')*
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b58748cfa4832d8860971fb46a5861