### PR TITLE
feat(rust): wire provider client to rust module

### DIFF
--- a/src/infrastructure/rust/rust-provider-client.ts
+++ b/src/infrastructure/rust/rust-provider-client.ts
@@ -1,6 +1,6 @@
 /**
  * Rust Provider Client - Phase 4 Implementation
- * 
+ *
  * Provides a client interface for interacting with Rust-backed services,
  * integrating with the existing provider system architecture.
  */
@@ -115,10 +115,10 @@ export class RustProviderClient implements ProviderClient {
       }
 
       const rustModule = this.bridgeManager.getRustModule();
-      
+
       // Execute the request through the Rust module
       const result = await this.executeRequest(rustModule, request);
-      
+
       // Update statistics
       const responseTime = Date.now() - startTime;
       this.updateStats(true, responseTime);
@@ -128,7 +128,7 @@ export class RustProviderClient implements ProviderClient {
       const responseTime = Date.now() - startTime;
       this.updateStats(false, responseTime);
       this.stats.lastError = error instanceof Error ? error : new Error(String(error));
-      
+
       logger.error('Rust provider execution failed:', error);
       throw error;
     }
@@ -177,35 +177,30 @@ export class RustProviderClient implements ProviderClient {
   }
 
   private async executeFileOperation(rustModule: any, request: any): Promise<any> {
-    // Placeholder for file operation execution
-    return {
-      type: 'file-operation-result',
-      success: true,
-      result: `File operation ${request.operation} completed`,
-    };
+    if (typeof rustModule.executeFilesystem !== 'function') {
+      throw new Error('File operation not supported by Rust module');
+    }
+
+    const { operation, path, content, options } = request;
+    return await rustModule.executeFilesystem(operation, path, content, options);
   }
 
   private async executeCodeAnalysis(rustModule: any, request: any): Promise<any> {
-    // Placeholder for code analysis execution
-    return {
-      type: 'code-analysis-result',
-      success: true,
-      result: {
-        linesOfCode: 100,
-        complexity: 'medium',
-        issues: [],
-      },
-    };
+    if (typeof rustModule.execute !== 'function') {
+      throw new Error('Code analysis not supported by Rust module');
+    }
+
+    const args = JSON.stringify(request);
+    return await rustModule.execute('code-analysis', args, request.options);
   }
 
   private async executeComputeTask(rustModule: any, request: any): Promise<any> {
-    // Placeholder for compute task execution
-    return {
-      type: 'compute-task-result',
-      success: true,
-      result: `Compute task ${request.taskId} completed`,
-      executionTime: 150,
-    };
+    if (typeof rustModule.execute !== 'function') {
+      throw new Error('Compute task not supported by Rust module');
+    }
+
+    const args = JSON.stringify(request);
+    return await rustModule.execute('compute-task', args, request.options);
   }
 
   private async executeGenericRequest(rustModule: any, request: any): Promise<any> {
@@ -214,7 +209,7 @@ export class RustProviderClient implements ProviderClient {
       const result = await rustModule.execute(JSON.stringify(request));
       return JSON.parse(result);
     }
-    
+
     throw new Error('Generic request execution not supported');
   }
 
@@ -227,7 +222,7 @@ export class RustProviderClient implements ProviderClient {
 
     // Update average response time using exponential moving average
     const alpha = 0.1;
-    this.stats.averageResponseTime = 
+    this.stats.averageResponseTime =
       alpha * responseTime + (1 - alpha) * this.stats.averageResponseTime;
   }
 }

--- a/tests/unit/infrastructure/rust/rust-provider-client.test.ts
+++ b/tests/unit/infrastructure/rust/rust-provider-client.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { RustProviderClient } from '../../../../src/infrastructure/rust/rust-provider-client.js';
+
+describe('RustProviderClient', () => {
+  let client: RustProviderClient;
+  let getRustModule: jest.Mock;
+  let isHealthy: jest.Mock;
+
+  beforeEach(() => {
+    client = new RustProviderClient();
+    getRustModule = jest.fn();
+    isHealthy = jest.fn(() => true);
+    // @ts-expect-error overriding for tests
+    client.bridgeManager = { getRustModule, isHealthy };
+  });
+
+  it('executes file operations via rust module', async () => {
+    const mockResponse = { success: true, result: 'ok' };
+    const rustModule = {
+      executeFilesystem: jest.fn().mockResolvedValue(mockResponse),
+    };
+    getRustModule.mockReturnValue(rustModule);
+
+    const request = {
+      type: 'file-operation',
+      operation: 'read',
+      path: '/tmp/file.txt',
+      content: null,
+      options: { encoding: 'utf8' },
+    };
+
+    const result = await client.execute(request);
+    expect(rustModule.executeFilesystem).toHaveBeenCalledWith('read', '/tmp/file.txt', null, {
+      encoding: 'utf8',
+    });
+    expect(result).toBe(mockResponse);
+  });
+
+  it('executes code analysis via rust module', async () => {
+    const mockResponse = { success: true, result: { lines: 10 } };
+    const rustModule = { execute: jest.fn().mockResolvedValue(mockResponse) };
+    getRustModule.mockReturnValue(rustModule);
+
+    const request = { type: 'code-analysis', code: 'let x = 1;' };
+    const result = await client.execute(request);
+
+    expect(rustModule.execute).toHaveBeenCalledWith(
+      'code-analysis',
+      JSON.stringify(request),
+      undefined
+    );
+    expect(result).toBe(mockResponse);
+  });
+
+  it('executes compute task via rust module', async () => {
+    const mockResponse = { success: true, result: 'done', execution_time_ms: 42 };
+    const rustModule = { execute: jest.fn().mockResolvedValue(mockResponse) };
+    getRustModule.mockReturnValue(rustModule);
+
+    const request = { type: 'compute-task', taskId: '123', payload: { n: 5 } };
+    const result = await client.execute(request);
+
+    expect(rustModule.execute).toHaveBeenCalledWith(
+      'compute-task',
+      JSON.stringify(request),
+      undefined
+    );
+    expect(result).toBe(mockResponse);
+  });
+});


### PR DESCRIPTION
## Summary
- delegate file operations to `executeFilesystem` and generic tasks to `execute`
- ensure code analysis and compute tasks forward directly to Rust and return native results
- cover RustProviderClient with unit tests using a mocked Rust module

## Testing
- `npm run lint:fix` *(fails: Cannot find package '/workspace/codecrucible-synth/node_modules/@typescript-eslint/eslint-plugin/index.js')*
- `npm run format`
- `npm run typecheck`
- `npm test` *(fails: Cannot find module 'jest-util')*

------
https://chatgpt.com/codex/tasks/task_e_68b589b3a554832d81222296aab30425