### PR TITLE
feat(rust-executor): report resource usage in heartbeat

### DIFF
--- a/rust-executor/Cargo.lock
+++ b/rust-executor/Cargo.lock
@@ -249,6 +249,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "sysinfo",
  "thiserror",
  "tokio",
  "tokio-test",
@@ -491,7 +492,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -711,6 +712,15 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1032,6 +1042,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,6 +1370,25 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-core"

--- a/rust-executor/Cargo.toml
+++ b/rust-executor/Cargo.toml
@@ -19,6 +19,8 @@ futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
+sysinfo = "0.30"
+
 # Cross-platform process management
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.27", features = ["process", "signal", "user", "fs"] }

--- a/rust-executor/src/protocol/communication.rs
+++ b/rust-executor/src/protocol/communication.rs
@@ -6,6 +6,7 @@ use tokio::time::{timeout, Duration};
 use serde_json;
 use tracing::{error, info, warn, debug};
 use async_trait::async_trait;
+use sysinfo::{System, SystemExt, ProcessExt, PidExt};
 
 use crate::protocol::messages::{
     ExecutionMessage, MessageType, MessagePayload, ExecutionRequest, ExecutionResponse,
@@ -147,6 +148,7 @@ pub struct CommunicationHandler {
     message_timeout: Duration,
     max_message_size: usize,
     max_messages_per_minute: usize,
+    system: Arc<RwLock<System>>,
 }
 
 #[derive(Debug, Clone)]
@@ -167,6 +169,7 @@ impl CommunicationHandler {
             message_timeout: Duration::from_secs(30),
             max_message_size: 10 * 1024 * 1024, // 10MB
             max_messages_per_minute: 60,
+            system: Arc::new(RwLock::new(System::new())),
         }
     }
 
@@ -409,10 +412,23 @@ impl CommunicationHandler {
             .unwrap_or_default()
             .as_millis() as u64;
             
-        // TODO: Get actual memory and CPU usage
-        let memory_usage = 0.0;
-        let cpu_usage = 0.0;
-        
+        // Get actual memory and CPU usage using sysinfo
+        let mut system = self.system.write().await;
+        let pid = sysinfo::Pid::from_u32(process_id);
+        system.refresh_process(pid);
+
+        let (memory_usage, cpu_usage) = if let Some(process) = system.process(pid) {
+            let mem_mb = process.memory() as f64 / 1024.0 / 1024.0;
+            let cpu = if system.cpus().len() > 0 {
+                process.cpu_usage() as f64 / system.cpus().len() as f64
+            } else {
+                0.0
+            };
+            (mem_mb, cpu)
+        } else {
+            (0.0, 0.0)
+        };
+
         Ok(ExecutionMessage::heartbeat(process_id, uptime, memory_usage, cpu_usage))
     }
 


### PR DESCRIPTION
## Summary
- gather process memory and CPU usage using sysinfo
- include resource metrics in heartbeat responses

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run format`
- `npm run typecheck` *(fails: Cannot find type definition file for '@types/node')*
- `npm test` *(fails: Cannot find module 'jest')*
- `cargo test` *(fails: unresolved crates and compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b589c5de1c832daf8ceae1d7a80f20