### PR TITLE
refactor(cli): modularize cli coordination

### DIFF
--- a/src/application/cli/cli-coordinator.ts
+++ b/src/application/cli/cli-coordinator.ts
@@ -1,0 +1,57 @@
+import { CommandParser } from './command-parser.js';
+import { InteractionManager } from './interaction-manager.js';
+import { SessionManager, CLISession } from './session-manager.js';
+import { OutputFormatter } from './output-formatter.js';
+
+/**
+ * CLICoordinator orchestrates parsing, interaction and session management for
+ * the command line experience. It intentionally delegates heavy lifting to
+ * dedicated helpers to keep this file lightweight and maintainable.
+ */
+export class CLICoordinator {
+  constructor(
+    private interaction = new InteractionManager(),
+    private sessions = new SessionManager(),
+    private formatter = new OutputFormatter()
+  ) {}
+
+  /**
+   * Entry point for CLI execution. Parses arguments and routes commands.
+   */
+  async run(argv: string[]): Promise<void> {
+    const { command } = CommandParser.parseArgs(argv);
+    const session = this.sessions.createSession();
+
+    if (!command) {
+      await this.repl(session);
+      return;
+    }
+
+    switch (command) {
+      case 'help':
+        this.formatter.showHelp();
+        break;
+      case 'models':
+        await this.formatter.showModels();
+        break;
+      default:
+        this.formatter.print(`Unknown command: ${command}`);
+    }
+
+    this.sessions.endSession(session.id);
+  }
+
+  /**
+   * Start interactive REPL-style session.
+   */
+  private async repl(session: CLISession): Promise<void> {
+    while (true) {
+      const line = await this.interaction.ask('> ');
+      if (line.trim() === 'exit') break;
+      const parsed = CommandParser.parseInput(line);
+      this.sessions.record(session.id, line);
+      this.formatter.print(`Intent: ${parsed.intent}`);
+    }
+    this.interaction.close();
+  }
+}

--- a/src/application/cli/cli-coordinator.ts
+++ b/src/application/cli/cli-coordinator.ts
@@ -45,13 +45,21 @@ export class CLICoordinator {
    * Start interactive REPL-style session.
    */
   private async repl(session: CLISession): Promise<void> {
-    while (true) {
+    let shouldContinue = true;
+    while (shouldContinue) {
       const line = await this.interaction.ask('> ');
-      if (line.trim() === 'exit') break;
+      if (this.shouldExit(line)) {
+        shouldContinue = false;
+        continue;
+      }
       const parsed = CommandParser.parseInput(line);
       this.sessions.record(session.id, line);
       this.formatter.print(`Intent: ${parsed.intent}`);
     }
     this.interaction.close();
+  }
+
+  private shouldExit(line: string): boolean {
+    return line.trim() === 'exit';
   }
 }

--- a/src/application/cli/command-parser.ts
+++ b/src/application/cli/command-parser.ts
@@ -29,7 +29,7 @@ export class CommandParser {
     const slash = CLIParser.parseSlashCommand(input);
     if (slash.command !== 'none') {
       return {
-        intent: slash.command as any,
+        intent: slash.command as ParsedCommand['intent'],
         confidence: 1,
         target: slash.role,
         originalInput: input,

--- a/src/application/cli/command-parser.ts
+++ b/src/application/cli/command-parser.ts
@@ -1,0 +1,41 @@
+import { CLIParser } from '../../core/cli/cli-parser.js';
+import {
+  naturalLanguageInterface,
+  ParsedCommand,
+} from '../../core/cli/natural-language-interface.js';
+import type { CLIOptions } from '../../core/cli/cli-types.js';
+
+/**
+ * CommandParser bridges low-level CLI parsing utilities from the core layer
+ * with application-level semantics. It exposes convenience helpers for
+ * processing raw command-line arguments and interactive user input.
+ */
+export class CommandParser {
+  /**
+   * Parse process arguments into structured CLI options and command.
+   */
+  static parseArgs(argv: string[]): { command: string; options: CLIOptions; args: string[] } {
+    // Remove node and script path
+    const args = argv.slice(2);
+    const { command, remainingArgs } = CLIParser.extractCommand(args);
+    const options = CLIParser.parseOptions(args);
+    return { command, options, args: remainingArgs };
+  }
+
+  /**
+   * Parse a raw input line, handling slash commands and natural language.
+   */
+  static parseInput(input: string): ParsedCommand {
+    const slash = CLIParser.parseSlashCommand(input);
+    if (slash.command !== 'none') {
+      return {
+        intent: slash.command as any,
+        confidence: 1,
+        target: slash.role,
+        originalInput: input,
+        enhancedQuery: slash.content,
+      };
+    }
+    return naturalLanguageInterface.parseCommand(input);
+  }
+}

--- a/src/application/cli/interaction-manager.ts
+++ b/src/application/cli/interaction-manager.ts
@@ -1,0 +1,23 @@
+import readline from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+
+/**
+ * InteractionManager centralizes all user-facing I/O for the CLI. It keeps
+ * readline usage contained so higher-level modules can remain agnostic of the
+ * underlying mechanism.
+ */
+export class InteractionManager {
+  private rl = readline.createInterface({ input, output });
+
+  async ask(prompt: string): Promise<string> {
+    return this.rl.question(prompt);
+  }
+
+  say(message: string): void {
+    output.write(`${message}\n`);
+  }
+
+  close(): void {
+    this.rl.close();
+  }
+}

--- a/src/application/cli/output-formatter.ts
+++ b/src/application/cli/output-formatter.ts
@@ -1,0 +1,20 @@
+import { CLIDisplay } from '../../core/cli/cli-display.js';
+
+/**
+ * OutputFormatter centralizes how results and messages are rendered in the
+ * terminal. It delegates rich formatting to core CLIDisplay utilities while
+ * keeping the application layer decoupled from presentation specifics.
+ */
+export class OutputFormatter {
+  showHelp(): void {
+    CLIDisplay.showHelp();
+  }
+
+  showModels(): Promise<void> {
+    return CLIDisplay.showModelRecommendations();
+  }
+
+  print(message: string): void {
+    console.log(message);
+  }
+}

--- a/src/application/cli/session-manager.ts
+++ b/src/application/cli/session-manager.ts
@@ -1,0 +1,43 @@
+import { randomUUID } from 'node:crypto';
+
+export interface CLISession {
+  id: string;
+  startTime: number;
+  history: string[];
+}
+
+/**
+ * SessionManager tracks CLI sessions and their lightweight history. It avoids
+ * unbounded memory growth by trimming history to a configurable size.
+ */
+export class SessionManager {
+  private sessions = new Map<string, CLISession>();
+  constructor(private historyLimit = 50) {}
+
+  createSession(): CLISession {
+    const session: CLISession = {
+      id: randomUUID(),
+      startTime: Date.now(),
+      history: [],
+    };
+    this.sessions.set(session.id, session);
+    return session;
+  }
+
+  getSession(id: string): CLISession | undefined {
+    return this.sessions.get(id);
+  }
+
+  endSession(id: string): void {
+    this.sessions.delete(id);
+  }
+
+  record(id: string, entry: string): void {
+    const session = this.sessions.get(id);
+    if (!session) return;
+    session.history.push(entry);
+    if (session.history.length > this.historyLimit) {
+      session.history.shift();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add application-level command parser wrapping core utilities
- centralize user I/O and session tracking for CLI interactions
- introduce lightweight CLI coordinator orchestrating parsing, interaction, and formatting

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npx prettier --write "src/application/cli/*.ts"`
- `npm run typecheck` *(fails: Cannot find type definitions for '@types/node', 'jest')*
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*


------
https://chatgpt.com/codex/tasks/task_e_68b635308a44832da21f6e20486cb284