### PR TITLE
refactor(config): modularize unified config manager

### DIFF
--- a/scripts/fix-logger-imports.js
+++ b/scripts/fix-logger-imports.js
@@ -2,7 +2,7 @@
 /**
  * Focused Logger Import Automation Script
  * Living Spiral Methodology - Automate mechanical, preserve architectural
- * 
+ *
  * SAFETY: Only handles proven Logger patterns from manual testing
  */
 
@@ -18,19 +18,19 @@ const __dirname = path.dirname(__filename);
 const loggerPatterns = [
   {
     find: /import\s*{\s*Logger\s*}\s*from\s*(['"][^'"]*logger\.js['"])\s*;?/g,
-    replace: "import { logger } from $1;",
-    description: "Logger import → logger import"
+    replace: 'import { logger } from $1;',
+    description: 'Logger import → logger import',
   },
   {
     find: /private\s+logger:\s*Logger\s*;/g,
-    replace: "private logger: typeof logger;",
-    description: "Logger type → typeof logger"
+    replace: 'private logger: typeof logger;',
+    description: 'Logger type → typeof logger',
   },
   {
     find: /this\.logger\s*=\s*new\s*Logger\([^)]*\)\s*;?/g,
-    replace: "this.logger = logger;",
-    description: "new Logger(...) → logger"
-  }
+    replace: 'this.logger = logger;',
+    description: 'new Logger(...) → logger',
+  },
 ];
 
 let totalChanges = 0;
@@ -39,7 +39,7 @@ let errorsFixed = 0;
 
 function fixLoggerInFile(filePath) {
   console.log(`\n📁 Processing: ${filePath}`);
-  
+
   if (!fs.existsSync(filePath)) {
     console.log(`  ⚠️  File not found: ${filePath}`);
     return false;
@@ -48,18 +48,18 @@ function fixLoggerInFile(filePath) {
   const content = fs.readFileSync(filePath, 'utf8');
   let modified = content;
   let changeCount = 0;
-  
+
   loggerPatterns.forEach(pattern => {
     const before = modified;
     modified = modified.replace(pattern.find, pattern.replace);
-    
+
     const matches = (before.match(pattern.find) || []).length;
     if (matches > 0) {
       changeCount += matches;
       console.log(`    ✓ ${pattern.description}: ${matches} fixes`);
     }
   });
-  
+
   if (changeCount > 0) {
     fs.writeFileSync(filePath, modified);
     console.log(`  📝 Applied ${changeCount} Logger fixes`);
@@ -75,38 +75,37 @@ function fixLoggerInFile(filePath) {
 function runTypecheck() {
   console.log('🔍 Running TypeScript validation...');
   try {
-    const result = execSync('npm run build', { 
+    const result = execSync('npm run build', {
       cwd: process.cwd(),
       encoding: 'utf8',
-      stdio: 'pipe'
+      stdio: 'pipe',
     });
-    
+
     console.log('✅ TypeScript compilation completed (clean build)');
     return { success: true, output: result, errorCount: 0 };
-    
   } catch (error) {
     const output = error.stdout || error.stderr || error.message;
-    
+
     // Extract error count from TypeScript output
     let errorCount = 0;
-    
-    // Count individual error lines  
-    const errorLines = output.split('\n').filter(line => 
-      line.match(/src\/.*\.ts\(\d+,\d+\): error TS\d+:/)
-    );
+
+    // Count individual error lines
+    const errorLines = output
+      .split('\n')
+      .filter(line => line.match(/src\/.*\.ts\(\d+,\d+\): error TS\d+:/));
     errorCount = errorLines.length;
-    
+
     // Also check for summary line like "Found 197 errors"
     const summaryMatch = output.match(/Found (\d+) errors?/);
     if (summaryMatch) {
       errorCount = Math.max(errorCount, parseInt(summaryMatch[1]));
     }
-    
+
     console.log(`📊 TypeScript errors found: ${errorCount}`);
-    return { 
-      success: false, 
+    return {
+      success: false,
       output: output,
-      errorCount: errorCount
+      errorCount: errorCount,
     };
   }
 }
@@ -114,13 +113,13 @@ function runTypecheck() {
 async function main() {
   console.log('🚀 Logger Import Automation Script - Living Spiral Approach');
   console.log('🎯 Target: Proven Logger patterns only (Zero business logic risk)');
-  
+
   // Get baseline error count
   console.log('\n📊 BASELINE: Getting initial error count...');
   const baseline = runTypecheck();
   const baselineErrors = baseline.errorCount;
   console.log(`📈 Baseline: ${baselineErrors} TypeScript errors`);
-  
+
   // First discover all files with Logger imports (use known list)
   console.log('\n🔍 DISCOVERY: Using known files with Logger imports...');
   const allLoggerFiles = [
@@ -142,7 +141,7 @@ async function main() {
     'src/core/unified-response-coordinator.ts',
     'src/domain/services/configuration-migrator.ts',
     'src/domain/services/living-spiral-coordinator.ts',
-    'src/domain/services/unified-configuration-manager.ts',
+    'src/domain/config/config-manager.ts',
     'src/domain/services/unified-performance-system.ts',
     'src/domain/services/unified-security-validator.ts',
     'src/domain/services/unified-server-system.ts',
@@ -153,7 +152,7 @@ async function main() {
     'src/infrastructure/production/setup-production-hardening.ts',
     'src/infrastructure/tools/advanced-tool-orchestrator.ts',
     'src/server/server-mode.ts',
-    'src/voices/voice-archetype-system.ts'
+    'src/voices/voice-archetype-system.ts',
   ];
   console.log(`📋 Processing ${allLoggerFiles.length} files with Logger imports`);
 
@@ -164,71 +163,77 @@ async function main() {
 
   // Test files (conservative approach - use first 3 files)
   const testFiles = allLoggerFiles.slice(0, 3);
-  
+
   console.log('\n🧪 PHASE 1: Testing on subset first (Living Spiral: Conservative Validation)');
   let testChanges = 0;
-  
+
   testFiles.forEach(filePath => {
     if (fixLoggerInFile(filePath)) {
       testChanges++;
     }
   });
-  
+
   if (testChanges === 0) {
     console.log('\n⚠️  No Logger patterns found in test files - script may not be needed');
     return;
   }
-  
+
   // Validate test changes
   console.log('\n🔍 VALIDATION: Measuring impact of test changes...');
   const testResult = runTypecheck();
   const testErrors = testResult.errorCount;
   const errorReduction = baselineErrors - testErrors;
-  
+
   console.log(`📊 Before: ${baselineErrors} errors → After: ${testErrors} errors`);
-  
+
   if (errorReduction > 0) {
     console.log(`✅ SUCCESS: Reduced ${errorReduction} errors with ${totalChanges} Logger fixes!`);
   } else if (errorReduction === 0) {
     console.log(`⚠️  NEUTRAL: No error reduction, but no regressions either`);
   } else {
-    console.log(`❌ REGRESSION: Errors increased by ${Math.abs(errorReduction)} - reverting needed`);
+    console.log(
+      `❌ REGRESSION: Errors increased by ${Math.abs(errorReduction)} - reverting needed`
+    );
     console.log('Output:', testResult.output.substring(0, 1000));
     return;
   }
-  
+
   if (testChanges === 0) {
-    console.log('\n⚠️  No Logger patterns found in remaining test files - continuing with discovery');
+    console.log(
+      '\n⚠️  No Logger patterns found in remaining test files - continuing with discovery'
+    );
   }
-  
+
   // Use remaining files (all discovered files minus test files)
   const remainingFiles = allLoggerFiles.slice(3); // Skip the first 3 used for testing
   console.log(`📋 ${remainingFiles.length} additional files to process after testing`);
-  
+
   if (remainingFiles.length === 0) {
     console.log('\n🎉 All Logger imports already fixed!');
     console.log(`📊 SUMMARY: ${totalChanges} changes applied to ${filesProcessed} files`);
     return;
   }
-  
+
   // Process remaining files
   console.log(`\n🔄 PHASE 2: Processing ${remainingFiles.length} remaining files...`);
-  
+
   remainingFiles.forEach(filePath => {
     fixLoggerInFile(filePath);
   });
-  
+
   // Final validation
   console.log('\n🔍 FINAL VALIDATION: Complete typecheck...');
   const finalResult = runTypecheck();
   const finalErrors = finalResult.errorCount;
   const totalErrorReduction = baselineErrors - finalErrors;
-  
+
   console.log('\n🎯 AUTOMATION RESULTS:');
   console.log(`📝 Files processed: ${filesProcessed}`);
   console.log(`🔧 Total Logger fixes applied: ${totalChanges}`);
-  console.log(`📊 Error reduction: ${baselineErrors} → ${finalErrors} (${totalErrorReduction >= 0 ? '-' : '+'}${Math.abs(totalErrorReduction)})`);
-  
+  console.log(
+    `📊 Error reduction: ${baselineErrors} → ${finalErrors} (${totalErrorReduction >= 0 ? '-' : '+'}${Math.abs(totalErrorReduction)})`
+  );
+
   if (totalErrorReduction > 0) {
     console.log(`\n🎉 SUCCESS: Eliminated ${totalErrorReduction} TypeScript errors!`);
     console.log('📈 Progress: Logger automation completed successfully');
@@ -241,11 +246,13 @@ async function main() {
     console.log('🔍 Recommend git restore and manual review');
     console.log('📝 Output preview:', finalResult.output.substring(0, 800));
   }
-  
-  console.log('\n💡 Next: Manual iteration using Living Spiral methodology on architectural issues');
+
+  console.log(
+    '\n💡 Next: Manual iteration using Living Spiral methodology on architectural issues'
+  );
 }
 
-// Execute if run directly  
+// Execute if run directly
 if (import.meta.url.startsWith('file:') && import.meta.url.includes('fix-logger-imports.js')) {
   main().catch(console.error);
 }

--- a/src/application/runtime/runtime-context.ts
+++ b/src/application/runtime/runtime-context.ts
@@ -8,9 +8,12 @@
  * injecting this object over importing singletons or using global setters.
  */
 import { IEventBus } from '../../domain/interfaces/event-bus.js';
-import { unifiedResourceCoordinator, UnifiedResourceCoordinator } from '../../infrastructure/performance/unified-resource-coordinator.js';
+import {
+  unifiedResourceCoordinator,
+  UnifiedResourceCoordinator,
+} from '../../infrastructure/performance/unified-resource-coordinator.js';
 import { UnifiedSecurityValidator } from '../../domain/services/unified-security-validator.js';
-import { UnifiedConfigurationManager } from '../../domain/services/unified-configuration-manager.js';
+import { UnifiedConfigurationManager } from '../../domain/config/config-manager.js';
 
 export interface RuntimeContext {
   eventBus: IEventBus;

--- a/src/application/services/service-factory.ts
+++ b/src/application/services/service-factory.ts
@@ -5,9 +5,18 @@
  */
 
 import { RuntimeContext, RuntimeContextFactory } from '../../core/runtime/runtime-context.js';
-import { UnifiedOrchestrationService, createUnifiedOrchestrationServiceWithContext } from '../../application/services/unified-orchestration-service.js';
-import { UnifiedConfigurationManager, createUnifiedConfigurationManager } from '../../domain/services/unified-configuration-manager.js';
-import { ConfigurableResourceCoordinator, ResourceCoordinatorFactory } from '../../infrastructure/performance/configurable-resource-coordinator.js';
+import {
+  UnifiedOrchestrationService,
+  createUnifiedOrchestrationServiceWithContext,
+} from '../../application/services/unified-orchestration-service.js';
+import {
+  UnifiedConfigurationManager,
+  createUnifiedConfigurationManager,
+} from '../../domain/config/config-manager.js';
+import {
+  ConfigurableResourceCoordinator,
+  ResourceCoordinatorFactory,
+} from '../../infrastructure/performance/configurable-resource-coordinator.js';
 import { createLogger } from '../../infrastructure/logging/logger-adapter.js';
 import { CLIUserInteraction } from '../../infrastructure/user-interaction/cli-user-interaction.js';
 import { EventBus } from '../../infrastructure/messaging/event-bus.js';
@@ -87,14 +96,14 @@ export class ServiceFactory {
     if (!this.resourceCoordinator) {
       this.resourceCoordinator = ResourceCoordinatorFactory.createHighPerformance();
 
-      // Note: RuntimeContext doesn't have setResourceCoordinator, 
+      // Note: RuntimeContext doesn't have setResourceCoordinator,
       // this is just storing for later disposal
     }
-    
+
     if (!this.resourceCoordinator) {
       throw new Error('Failed to create resource coordinator');
     }
-    
+
     return this.resourceCoordinator;
   }
 
@@ -114,7 +123,7 @@ export class ServiceFactory {
       // Just clean up reference
       this.resourceCoordinator = undefined;
     }
-    
+
     await this.runtimeContext.dispose();
   }
 
@@ -160,9 +169,7 @@ export async function createProductionOrchestrationService(
 /**
  * Create a test-friendly orchestration service with mocked dependencies
  */
-export async function createTestOrchestrationService(
-  config: ServiceFactoryConfig = {}
-): Promise<{
+export async function createTestOrchestrationService(config: ServiceFactoryConfig = {}): Promise<{
   service: UnifiedOrchestrationService;
   factory: ServiceFactory;
   context: RuntimeContext;

--- a/src/application/services/unified-orchestration-service.ts
+++ b/src/application/services/unified-orchestration-service.ts
@@ -10,7 +10,7 @@ import { EventEmitter } from 'events';
 import { IEventBus } from '../../domain/interfaces/event-bus.js';
 import { IUserInteraction } from '../../domain/interfaces/user-interaction.js';
 import { UnifiedConfiguration } from '../../domain/interfaces/configuration.js';
-import { UnifiedConfigurationManager } from '../../domain/services/unified-configuration-manager.js';
+import { UnifiedConfigurationManager } from '../../domain/config/config-manager.js';
 import { UnifiedAgentSystem } from '../../domain/services/unified-agent-system.js';
 import { UnifiedServerSystem } from '../../domain/services/unified-server-system.js';
 import { UnifiedSecurityValidator } from '../../domain/services/unified-security-validator.js';
@@ -242,7 +242,10 @@ export class UnifiedOrchestrationService extends EventEmitter {
         case 'debug':
         case 'optimize':
           if (!this.commandBus) throw new Error('Command bus not initialized');
-          result = await this.commandBus.execute({ type: `agent:${request.type}`, payload: { request } });
+          result = await this.commandBus.execute({
+            type: `agent:${request.type}`,
+            payload: { request },
+          });
           componentsUsed.push('AgentSystem');
           break;
 
@@ -750,8 +753,12 @@ export class UnifiedOrchestrationService extends EventEmitter {
 
   // === Plugin Command Registry Bridge ===
 
-  listPluginCommands(): Array<{ name: string; description?: string; plugin?: string; version?: string }>
-  {
+  listPluginCommands(): Array<{
+    name: string;
+    description?: string;
+    plugin?: string;
+    version?: string;
+  }> {
     if (!this.commandRegistry) return [];
     try {
       return this.commandRegistry.list().map(c => ({

--- a/src/config/config-manager.ts
+++ b/src/config/config-manager.ts
@@ -7,7 +7,7 @@
  * @deprecated Use UnifiedConfigurationManager from domain/services instead
  */
 
-import { UnifiedConfigurationManager } from '../domain/services/unified-configuration-manager.js';
+import { UnifiedConfigurationManager } from '../domain/config/config-manager.js';
 import { UnifiedConfiguration } from '../domain/types/index.js';
 import { createLogger } from '../infrastructure/logging/logger-adapter.js';
 
@@ -71,11 +71,15 @@ export class ConfigManager {
   private convertToLegacyFormat(unified: UnifiedConfiguration): AppConfig {
     return {
       model: {
-        endpoint: unified.model.providers[0]?.endpoint || process.env.OLLAMA_ENDPOINT || 'http://localhost:11434',
+        endpoint:
+          unified.model.providers[0]?.endpoint ||
+          process.env.OLLAMA_ENDPOINT ||
+          'http://localhost:11434',
         name: unified.model.defaultModel || process.env.MODEL_DEFAULT_NAME,
         timeout: unified.model.timeout || parseInt(process.env.REQUEST_TIMEOUT || '30000'),
         maxTokens: unified.model.maxTokens || parseInt(process.env.MODEL_MAX_TOKENS || '131072'),
-        temperature: unified.model.temperature || parseFloat(process.env.MODEL_TEMPERATURE || '0.7'),
+        temperature:
+          unified.model.temperature || parseFloat(process.env.MODEL_TEMPERATURE || '0.7'),
       },
       llmProviders: {
         default: unified.model.defaultProvider || 'ollama',
@@ -137,7 +141,10 @@ export class ConfigManager {
             provider: 'ollama',
             endpoint: 'http://localhost:11434',
             enabled: true,
-            models: [process.env.MODEL_DEFAULT_NAME || 'qwen2.5-coder:7b', 'deepseek-coder:8b'].filter(Boolean),
+            models: [
+              process.env.MODEL_DEFAULT_NAME || 'qwen2.5-coder:7b',
+              'deepseek-coder:8b',
+            ].filter(Boolean),
           },
         },
       },

--- a/src/core/cli/config-commands.ts
+++ b/src/core/cli/config-commands.ts
@@ -4,7 +4,7 @@
  * Command-line interface for configuration management and migration.
  */
 
-import { UnifiedConfigurationManager } from '../../domain/services/unified-configuration-manager.js';
+import { UnifiedConfigurationManager } from '../../domain/config/config-manager.js';
 import { ConfigurationMigrator } from '../../domain/services/configuration-migrator.js';
 import { createLogger } from '../../infrastructure/logging/logger-adapter.js';
 import { join } from 'path';

--- a/src/core/services/unified-config-service.ts
+++ b/src/core/services/unified-config-service.ts
@@ -10,7 +10,7 @@
  */
 
 // Re-export the properly layered domain implementation
-export * from '../../domain/services/unified-configuration-manager.js';
+export * from '../../domain/config/config-manager.js';
 export * from '../../domain/interfaces/configuration.js';
 
 // For backward compatibility, provide type aliases for old naming conventions
@@ -65,10 +65,10 @@ export interface ConfigOptions {
 }
 
 // Export the class as a value, not just a type
-export { UnifiedConfigurationManager as UnifiedConfigService } from '../../domain/services/unified-configuration-manager.js';
+export { UnifiedConfigurationManager as UnifiedConfigService } from '../../domain/config/config-manager.js';
 
 // Create a singleton instance for backward compatibility
-import { UnifiedConfigurationManager } from '../../domain/services/unified-configuration-manager.js';
+import { UnifiedConfigurationManager } from '../../domain/config/config-manager.js';
 import { createLogger } from '../../infrastructure/logging/logger-adapter.js';
 
 const logger = createLogger('UnifiedConfigService');

--- a/src/core/services/unified-orchestration-service.ts
+++ b/src/core/services/unified-orchestration-service.ts
@@ -152,7 +152,7 @@ import {
   createUnifiedOrchestrationService,
   UnifiedOrchestrationService,
 } from '../../application/services/unified-orchestration-service.js';
-import { getUnifiedConfigurationManager } from '../../domain/services/unified-configuration-manager.js';
+import { getUnifiedConfigurationManager } from '../../domain/config/config-manager.js';
 
 let _unifiedOrchestrationServiceInstance: UnifiedOrchestrationService | null = null;
 

--- a/src/domain/config/config-loader.ts
+++ b/src/domain/config/config-loader.ts
@@ -1,0 +1,30 @@
+import { dirname } from 'path';
+import type { UnifiedConfiguration } from '../interfaces/configuration.js';
+import { validateConfiguration } from './config-validator.js';
+
+export async function loadConfigFile(filePath: string): Promise<Partial<UnifiedConfiguration>> {
+  try {
+    const { readFile, access } = await import('fs/promises');
+    const { default: YAML } = await import('yaml');
+    await access(filePath);
+    const content = await readFile(filePath, 'utf-8');
+    const parsed = YAML.parse(content) as Partial<UnifiedConfiguration>;
+    const validation = validateConfiguration(parsed);
+    if (!validation.isValid) {
+      throw new Error(`Invalid configuration: ${validation.errors.map(e => e.message).join(', ')}`);
+    }
+    return parsed;
+  } catch {
+    return {};
+  }
+}
+
+export async function saveConfigFile(
+  filePath: string,
+  config: UnifiedConfiguration
+): Promise<void> {
+  const { writeFile, mkdir } = await import('fs/promises');
+  const { default: YAML } = await import('yaml');
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, YAML.stringify(config), 'utf-8');
+}

--- a/src/domain/config/config-loader.ts
+++ b/src/domain/config/config-loader.ts
@@ -14,7 +14,8 @@ export async function loadConfigFile(filePath: string): Promise<Partial<UnifiedC
       throw new Error(`Invalid configuration: ${validation.errors.map(e => e.message).join(', ')}`);
     }
     return parsed;
-  } catch {
+  } catch (err) {
+    console.error(`Failed to load config file "${filePath}":`, err);
     return {};
   }
 }

--- a/src/domain/config/config-manager.ts
+++ b/src/domain/config/config-manager.ts
@@ -1,0 +1,137 @@
+import { EventEmitter } from 'events';
+import { join, dirname } from 'path';
+import { homedir } from 'os';
+import type { IEventBus } from '../interfaces/event-bus.js';
+import type { ILogger } from '../interfaces/logger.js';
+import {
+  UnifiedConfiguration,
+  ConfigurationValidation,
+  ConfigurationSource,
+} from '../interfaces/configuration.js';
+import { getDefaultConfig, mergeConfigurations, resolveConfig } from './config-hierarchy.js';
+import { saveConfigFile } from './config-loader.js';
+import { validateConfiguration } from './config-validator.js';
+import { ConfigWatcher } from './config-watcher.js';
+
+export interface IUnifiedConfigurationManager {
+  initialize(): Promise<void>;
+  loadConfiguration(): Promise<UnifiedConfiguration>;
+  getConfiguration(): UnifiedConfiguration;
+  updateConfiguration(
+    updates: Partial<UnifiedConfiguration>,
+    source: ConfigurationSource
+  ): Promise<void>;
+  validateConfiguration(config: Partial<UnifiedConfiguration>): ConfigurationValidation;
+  saveConfiguration(filePath?: string): Promise<void>;
+  resetToDefaults(): Promise<void>;
+  watchForChanges(enabled: boolean): void;
+}
+
+export class UnifiedConfigurationManager
+  extends EventEmitter
+  implements IUnifiedConfigurationManager
+{
+  private currentConfig!: UnifiedConfiguration;
+  private watcher?: ConfigWatcher;
+  private isInitialized = false;
+
+  constructor(
+    private logger: ILogger,
+    private configFilePath: string = join(homedir(), '.codecrucible', 'config.yaml'),
+    private eventBus?: IEventBus
+  ) {
+    super();
+  }
+
+  async initialize(): Promise<void> {
+    const { mkdir } = await import('fs/promises');
+    await mkdir(dirname(this.configFilePath), { recursive: true });
+    this.currentConfig = await resolveConfig(this.configFilePath);
+    this.isInitialized = true;
+    this.emit('initialized', this.currentConfig);
+    this.eventBus?.emit('system:initialize', {
+      component: 'UnifiedConfigurationManager',
+    });
+  }
+
+  async loadConfiguration(): Promise<UnifiedConfiguration> {
+    this.currentConfig = await resolveConfig(this.configFilePath);
+    return this.currentConfig;
+  }
+
+  getConfiguration(): UnifiedConfiguration {
+    return this.currentConfig;
+  }
+
+  async updateConfiguration(
+    updates: Partial<UnifiedConfiguration>,
+    source: ConfigurationSource
+  ): Promise<void> {
+    const merged = mergeConfigurations({ ...this.currentConfig }, updates);
+    const validation = validateConfiguration(merged);
+    if (!validation.isValid) {
+      throw new Error(`Invalid configuration: ${validation.errors.map(e => e.message).join(', ')}`);
+    }
+    this.currentConfig = merged;
+    await saveConfigFile(this.configFilePath, this.currentConfig);
+    this.emit('updated', { config: this.currentConfig, source });
+  }
+
+  validateConfiguration(config: Partial<UnifiedConfiguration>): ConfigurationValidation {
+    return validateConfiguration(config);
+  }
+
+  async saveConfiguration(filePath?: string): Promise<void> {
+    await saveConfigFile(filePath || this.configFilePath, this.currentConfig);
+  }
+
+  async resetToDefaults(): Promise<void> {
+    this.currentConfig = getDefaultConfig();
+    await this.saveConfiguration();
+    this.emit('reset', this.currentConfig);
+  }
+
+  watchForChanges(enabled: boolean): void {
+    if (enabled) {
+      if (!this.watcher) {
+        this.watcher = new ConfigWatcher(this.configFilePath, async () => {
+          this.logger.info('Configuration file changed, reloading');
+          this.currentConfig = await resolveConfig(this.configFilePath);
+          this.emit('reloaded', this.currentConfig);
+        });
+      }
+      this.watcher.start();
+    } else {
+      this.watcher?.stop();
+    }
+  }
+}
+
+let singleton: UnifiedConfigurationManager | null = null;
+export async function getUnifiedConfigurationManager(): Promise<UnifiedConfigurationManager> {
+  if (!singleton) {
+    const { createLogger } = await import('../../infrastructure/logging/logger-adapter.js');
+    singleton = new UnifiedConfigurationManager(createLogger('UnifiedConfigurationManager'));
+    await singleton.initialize();
+  }
+  return singleton;
+}
+
+export async function createUnifiedConfigurationManager(options?: {
+  logger?: ILogger;
+  configFilePath?: string;
+  eventBus?: IEventBus;
+}): Promise<UnifiedConfigurationManager> {
+  const logger =
+    options?.logger ||
+    (await import('../../infrastructure/logging/logger-adapter.js')).createLogger(
+      'UnifiedConfigurationManager'
+    );
+  const manager = new UnifiedConfigurationManager(
+    logger,
+    options?.configFilePath,
+    options?.eventBus
+  );
+  await manager.initialize();
+  return manager;
+}

--- a/src/domain/config/config-validator.ts
+++ b/src/domain/config/config-validator.ts
@@ -20,7 +20,13 @@ export function validateConfiguration(
       });
     }
     const envs = ['development', 'production', 'testing', 'staging'];
-    if (!envs.includes(config.application.environment)) {
+    if (!config.application.environment) {
+      errors.push({
+        field: 'application.environment',
+        message: 'App environment is required',
+        severity: 'error',
+      });
+    } else if (!envs.includes(config.application.environment)) {
       errors.push({
         field: 'application.environment',
         message: 'Invalid environment',

--- a/src/domain/config/config-validator.ts
+++ b/src/domain/config/config-validator.ts
@@ -1,0 +1,63 @@
+import {
+  UnifiedConfiguration,
+  ConfigurationValidation,
+  ConfigurationError,
+  ConfigurationWarning,
+} from '../interfaces/configuration.js';
+
+export function validateConfiguration(
+  config: Partial<UnifiedConfiguration>
+): ConfigurationValidation {
+  const errors: ConfigurationError[] = [];
+  const warnings: ConfigurationWarning[] = [];
+
+  if (config.application) {
+    if (!config.application.name) {
+      errors.push({
+        field: 'application.name',
+        message: 'App name is required',
+        severity: 'error',
+      });
+    }
+    const envs = ['development', 'production', 'testing', 'staging'];
+    if (!envs.includes(config.application.environment)) {
+      errors.push({
+        field: 'application.environment',
+        message: 'Invalid environment',
+        severity: 'error',
+      });
+    }
+  }
+
+  if (config.model?.providers && config.model.providers.length === 0) {
+    warnings.push({
+      field: 'model.providers',
+      message: 'No model providers configured',
+      suggestion: 'Add at least one provider',
+    });
+  }
+
+  if (config.model?.timeout && config.model.timeout < 1000) {
+    warnings.push({
+      field: 'model.timeout',
+      message: 'Timeout very low',
+      suggestion: 'Consider increasing timeout',
+    });
+  }
+
+  if (config.security?.securityLevel === 'low') {
+    warnings.push({
+      field: 'security.securityLevel',
+      message: 'Low security level enabled',
+    });
+  }
+
+  if (config.performance?.maxConcurrentRequests && config.performance.maxConcurrentRequests > 10) {
+    warnings.push({
+      field: 'performance.maxConcurrentRequests',
+      message: 'High concurrency may cause issues',
+    });
+  }
+
+  return { isValid: errors.length === 0, errors, warnings };
+}

--- a/src/domain/config/config-watcher.ts
+++ b/src/domain/config/config-watcher.ts
@@ -10,9 +10,11 @@ export class ConfigWatcher {
 
   start(): void {
     if (this.watcher) return;
-    this.watcher = watch(this.filePath, async event => {
-      if (event === 'change') {
-        await this.onChange();
+        try {
+          await this.onChange();
+        } catch (error) {
+          console.error('Error in ConfigWatcher onChange callback:', error);
+        }
       }
     });
   }

--- a/src/domain/config/config-watcher.ts
+++ b/src/domain/config/config-watcher.ts
@@ -1,0 +1,24 @@
+import { watch, FSWatcher } from 'fs';
+
+export class ConfigWatcher {
+  private watcher?: FSWatcher;
+
+  constructor(
+    private filePath: string,
+    private onChange: () => Promise<void>
+  ) {}
+
+  start(): void {
+    if (this.watcher) return;
+    this.watcher = watch(this.filePath, async event => {
+      if (event === 'change') {
+        await this.onChange();
+      }
+    });
+  }
+
+  stop(): void {
+    this.watcher?.close();
+    this.watcher = undefined;
+  }
+}

--- a/src/domain/services/configuration-migrator.ts
+++ b/src/domain/services/configuration-migrator.ts
@@ -10,7 +10,7 @@ import { join, dirname } from 'path';
 import { existsSync } from 'fs';
 import YAML from 'yaml';
 import { UnifiedConfiguration } from '../interfaces/configuration.js';
-import { UnifiedConfigurationManager } from './unified-configuration-manager.js';
+import { UnifiedConfigurationManager } from '../config/config-manager.js';
 import { ILogger } from '../interfaces/logger.js';
 
 export interface MigrationAnalysis {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export { MCPServerManager } from './mcp-servers/mcp-server-manager.js';
 
 // Export domain services
 export { UnifiedAgentSystem } from './domain/services/unified-agent-system.js';
-export { UnifiedConfigurationManager } from './domain/services/unified-configuration-manager.js';
+export { UnifiedConfigurationManager } from './domain/config/config-manager.js';
 export { UnifiedSecurityValidator } from './domain/services/unified-security-validator.js';
 export { UnifiedPerformanceSystem } from './domain/services/unified-performance-system.js';
 export { UnifiedServerSystem } from './domain/services/unified-server-system.js';
@@ -97,25 +97,71 @@ export async function initialize(): Promise<UnifiedCLI> {
         enabled: true,
         allowedCommands: [
           // Basic commands
-          'ls', 'cat', 'echo', 'pwd', 'which', 'node', 'npm',
+          'ls',
+          'cat',
+          'echo',
+          'pwd',
+          'which',
+          'node',
+          'npm',
           // Safe search commands for development workflows
-          'grep', 'rg', 'ripgrep', 'find', 'locate', 'ack', 'ag', 'fzf',
+          'grep',
+          'rg',
+          'ripgrep',
+          'find',
+          'locate',
+          'ack',
+          'ag',
+          'fzf',
           // File inspection commands
-          'head', 'tail', 'less', 'more', 'wc', 'sort', 'uniq',
+          'head',
+          'tail',
+          'less',
+          'more',
+          'wc',
+          'sort',
+          'uniq',
           // Development tools
-          'git', 'diff', 'curl', 'wget', 'jq', 'yq',
+          'git',
+          'diff',
+          'curl',
+          'wget',
+          'jq',
+          'yq',
         ],
         blockedCommands: [
           // Destructive file operations
-          'rm', 'rmdir', 'unlink', 'mv', 'cp',
+          'rm',
+          'rmdir',
+          'unlink',
+          'mv',
+          'cp',
           // System administration
-          'sudo', 'su', 'chmod', 'chown', 'chgrp',
+          'sudo',
+          'su',
+          'chmod',
+          'chown',
+          'chgrp',
           // Process management
-          'kill', 'pkill', 'killall', 'nohup', 'bg', 'fg',
+          'kill',
+          'pkill',
+          'killall',
+          'nohup',
+          'bg',
+          'fg',
           // Network security risks
-          'nc', 'netcat', 'telnet', 'ssh', 'scp', 'rsync',
+          'nc',
+          'netcat',
+          'telnet',
+          'ssh',
+          'scp',
+          'rsync',
           // System modification
-          'mount', 'umount', 'fdisk', 'mkfs', 'dd',
+          'mount',
+          'umount',
+          'fdisk',
+          'mkfs',
+          'dd',
         ],
       },
       packageManager: {
@@ -137,12 +183,15 @@ export async function initialize(): Promise<UnifiedCLI> {
       await mcpServerManager.startServers();
       logger.info('✅ MCP servers are ready for tool execution');
     } catch (error) {
-      logger.warn('⚠️ MCP servers initialization had issues, continuing with degraded capabilities:', error);
+      logger.warn(
+        '⚠️ MCP servers initialization had issues, continuing with degraded capabilities:',
+        error
+      );
       // Continue without MCP servers - graceful degradation
     }
 
     // Create concrete workflow orchestrator (breaks circular dependencies)
-  const orchestrator = new ConcreteWorkflowOrchestrator();
+    const orchestrator = new ConcreteWorkflowOrchestrator();
 
     // Initialize proper UnifiedModelClient with dynamic model selection
     const { UnifiedModelClient } = await import('./application/services/unified-model-client.js');
@@ -298,8 +347,12 @@ export async function main(): Promise<void> {
       // Avoid forced exit to let stdout flush naturally
     };
 
-    process.on('SIGINT', () => { cleanup().finally(() => {}); });
-    process.on('SIGTERM', () => { cleanup().finally(() => {}); });
+    process.on('SIGINT', () => {
+      cleanup().finally(() => {});
+    });
+    process.on('SIGTERM', () => {
+      cleanup().finally(() => {});
+    });
     // Note: do not attach to 'exit' to avoid recursive exits
 
     // Run CLI with arguments

--- a/src/server/server-mode.ts
+++ b/src/server/server-mode.ts
@@ -12,7 +12,7 @@ import {
   ServerConfiguration,
   ServerStatus,
 } from '../domain/services/unified-server-system.js';
-import { UnifiedConfigurationManager } from '../domain/services/unified-configuration-manager.js';
+import { UnifiedConfigurationManager } from '../domain/config/config-manager.js';
 import { EventBus } from '../infrastructure/messaging/event-bus.js';
 import { UnifiedSecurityValidator } from '../domain/services/unified-security-validator.js';
 import { UnifiedPerformanceSystem } from '../domain/services/unified-performance-system.js';


### PR DESCRIPTION
## Summary
- split monolithic configuration manager into loader, validator, hierarchy, watcher and orchestrator modules
- update imports to new config manager across services and tooling

## Testing
- `npx prettier --write scripts/fix-logger-imports.js src/application/runtime/runtime-context.ts src/application/services/concrete-workflow-orchestrator.ts src/application/services/service-factory.ts src/application/services/unified-orchestration-service.ts src/config/config-manager.ts src/core/cli/config-commands.ts src/core/services/unified-config-service.ts src/core/services/unified-orchestration-service.ts src/domain/services/configuration-migrator.ts src/index.ts src/server/server-mode.ts src/domain/config/config-hierarchy.ts src/domain/config/config-loader.ts src/domain/config/config-manager.ts src/domain/config/config-validator.ts src/domain/config/config-watcher.ts`
- `npx eslint scripts/fix-logger-imports.js src/application/runtime/runtime-context.ts src/application/services/concrete-workflow-orchestrator.ts src/application/services/service-factory.ts src/application/services/unified-orchestration-service.ts src/config/config-manager.ts src/core/cli/config-commands.ts src/core/services/unified-config-service.ts src/core/services/unified-orchestration-service.ts src/domain/services/configuration-migrator.ts src/index.ts src/server/server-mode.ts src/domain/config/config-hierarchy.ts src/domain/config/config-loader.ts src/domain/config/config-manager.ts src/domain/config/config-validator.ts src/domain/config/config-watcher.ts` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck` *(fails: Cannot find type definition file for '@types/node' and 'jest')*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68b634d13e18832d8b0126463750df82