### PR TITLE
feat(mcp): scaffold voice bridge modules

### DIFF
--- a/src/core/mcp/mcp-voice-coordinator.ts
+++ b/src/core/mcp/mcp-voice-coordinator.ts
@@ -83,7 +83,16 @@ export class MCPVoiceCoordinator extends EventEmitter {
       this.logger.debug('Selected connection', { decision });
 
       // Placeholder: security and reliability checks
-      enhancedMCPSecuritySystem.validateRequest(mcpContext);
+      try {
+        const validationResult = enhancedMCPSecuritySystem.validateRequest(mcpContext);
+        if (validationResult === false) {
+          throw new Error('Security validation failed: validateRequest returned false for the provided context.');
+        }
+      } catch (err) {
+        throw new Error(
+          `Security validation failed for requestId=${request.requestId}, voiceId=${request.voiceId}: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
       const safeContext = await enhancedMCPReliabilitySystem.executeWithRetries(
         async () => mcpContext
       );

--- a/src/core/mcp/mcp-voice-coordinator.ts
+++ b/src/core/mcp/mcp-voice-coordinator.ts
@@ -18,6 +18,9 @@ import { voiceToolMapper, VoiceToolMapper } from './voice-tool-mapper.js';
 import { contextTranslator, ContextTranslator } from './context-translator.js';
 import { responseSynthesizer, ResponseSynthesizer } from './response-synthesizer.js';
 import { integrationMonitor, IntegrationMonitor } from './integration-monitor.js';
+import { intelligentMCPLoadBalancer } from './intelligent-mcp-load-balancer.js';
+import { enhancedMCPSecuritySystem } from './enhanced-mcp-security-system.js';
+import { enhancedMCPReliabilitySystem } from './enhanced-mcp-reliability-system.js';
 
 export interface MCPVoiceRequest {
   requestId: string;
@@ -67,9 +70,17 @@ export class MCPVoiceCoordinator extends EventEmitter {
       // Translate voice context to MCP friendly structure
       const mcpContext = this.translator.toMCPContext(request.context);
 
-      // Placeholder: choose server via discovery/load balancer
-      const decision = await _intelligentMCPLoadBalancer.selectServer(server);
-      this.logger.debug('Selected server', { decision });
+      // Placeholder: choose connection via discovery/load balancer
+      const decision = await intelligentMCPLoadBalancer.getConnection(
+        'default',
+        [request.capability],
+        request.requestId,
+        mcpContext
+      );
+      if (!decision) {
+        throw new Error('No available MCP connection');
+      }
+      this.logger.debug('Selected connection', { decision });
 
       // Placeholder: security and reliability checks
       enhancedMCPSecuritySystem.validateRequest(mcpContext);


### PR DESCRIPTION
## Summary
- add voice-tool-mapper for capability to MCP tool relationships
- add context translator and response synthesizer for bridging voice context and MCP output
- add integration monitor and coordinator skeleton to orchestrate voice-driven MCP requests
- export new bridge components via core MCP index
- import available load balancer and security systems and replace undefined server selection

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npx prettier src/core/mcp/mcp-voice-coordinator.ts -w`
- `npm run typecheck` *(fails: Cannot find type definition file for '@types/node')*
- `npm test` *(fails: Cannot find module 'node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b638a3106c832d950aea00957ec9b9