### PR TITLE
fix: handle missing adapters and stream token metadata

### DIFF
--- a/src/application/services/model-client.ts
+++ b/src/application/services/model-client.ts
@@ -14,7 +14,7 @@ import { ILogger } from '../../domain/interfaces/logger.js';
 import { logger as defaultLogger } from '../../infrastructure/logging/unified-logger.js';
 
 export interface ModelClientOptions {
-  adapters: ProviderAdapter[];
+  adapters?: ProviderAdapter[];
   requestProcessor?: RequestProcessor;
   responseHandler?: ResponseHandler;
   streamingManager?: StreamingManager;
@@ -30,7 +30,8 @@ export class ModelClient extends EventEmitter implements IModelClient {
 
   constructor(options: ModelClientOptions) {
     super();
-    this.adapters = new Map(options.adapters.map(a => [a.name, a]));
+    const providedAdapters = options.adapters ?? [];
+    this.adapters = new Map(providedAdapters.map(a => [a.name, a]));
     this.requestProcessor = options.requestProcessor ?? new BasicRequestProcessor();
     this.responseHandler = options.responseHandler ?? new BasicResponseHandler();
     this.streamingManager = options.streamingManager ?? new BasicStreamingManager();

--- a/src/application/services/provider-adapters.ts
+++ b/src/application/services/provider-adapters.ts
@@ -79,10 +79,17 @@ export class LMStudioAdapter implements ProviderAdapter {
     const streamFn = (this.provider as any).stream;
     if (!streamFn) return;
     const iterator = await streamFn.call(this.provider, req);
+    let index = 0;
     for await (const token of iterator as any) {
-      yield { content: (token as any).content ?? String(token), isComplete: false };
+      yield {
+        content: (token as any).content ?? String(token),
+        isComplete: false,
+        index,
+        timestamp: Date.now(),
+      };
+      index++;
     }
-    yield { content: '', isComplete: true };
+    yield { content: '', isComplete: true, index, timestamp: Date.now() };
   }
 
   async getModels(): Promise<string[]> {
@@ -106,7 +113,7 @@ export class ClaudeAdapter implements ProviderAdapter {
     const body = {
       model: req.model || 'claude-3-sonnet-20240229',
       max_tokens: req.maxTokens || 1024,
-      messages: req.messages ?? [{ role: 'user', content: req.prompt }],
+      messages: (req as any).messages ?? [{ role: 'user', content: req.prompt }],
       temperature: req.temperature ?? 0.7,
     };
     const response = await fetch(this.endpoint, {

--- a/src/core/interfaces/client-interfaces.ts
+++ b/src/core/interfaces/client-interfaces.ts
@@ -19,8 +19,8 @@ export type { ProjectContext, ModelRequest, ModelResponse };
 export interface StreamToken {
   content: string;
   isComplete: boolean;
-  index?: number;
-  timestamp?: number;
+  index: number;
+  timestamp: number;
   metadata?: Record<string, unknown>;
 }
 

--- a/src/domain/interfaces/model-client.ts
+++ b/src/domain/interfaces/model-client.ts
@@ -22,7 +22,7 @@ export interface ModelRequest {
     tool_calls?: any[];
     tool_call_id?: string;
   }>;
-  // Ollama-specific parameters  
+  // Ollama-specific parameters
   num_ctx?: number;
   options?: Record<string, any>;
 }
@@ -82,6 +82,8 @@ export interface RequestContext {
 export interface StreamToken {
   content: string;
   isComplete: boolean;
+  index: number;
+  timestamp: number;
   metadata?: Record<string, any>;
 }
 

--- a/src/domain/types/core-types.ts
+++ b/src/domain/types/core-types.ts
@@ -9,9 +9,9 @@
 
 export interface StreamToken {
   content: string;
-  timestamp?: number;
-  index?: number;
-  isComplete?: boolean;
+  timestamp: number;
+  index: number;
+  isComplete: boolean;
   metadata?: Record<string, any>;
   finishReason?: string;
   usage?: {


### PR DESCRIPTION
## Summary
- allow ModelClient to be constructed without adapters and map them defensively
- add index and timestamp to streamed tokens and access optional request messages safely
- require StreamToken index and timestamp across shared interfaces

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run format`
- `npm run typecheck` *(fails: Cannot find type definition file for '@types/node'; Cannot find type definition file for 'jest')*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68b639206cb4832db679b5c75d685c20