### PR TITLE
fix: address review comments in output modules

### DIFF
--- a/src/core/output/format-transformer.ts
+++ b/src/core/output/format-transformer.ts
@@ -1,4 +1,5 @@
-import yaml from 'yaml';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
 
 /**
  * FormatTransformer converts structured data into common output formats.
@@ -9,8 +10,16 @@ class FormatTransformer {
    */
   to(format: 'json' | 'yaml' | 'markdown', data: unknown): string {
     switch (format) {
-      case 'yaml':
-        return yaml.stringify(data);
+      case 'yaml': {
+        try {
+          const yaml = require('yaml');
+          return yaml.stringify(data);
+        } catch {
+          throw new Error(
+            "The 'yaml' package is required for YAML output. Install it with `npm install yaml`."
+          );
+        }
+      }
       case 'markdown':
         if (typeof data === 'string') {
           return data;

--- a/src/core/output/output-coordinator.ts
+++ b/src/core/output/output-coordinator.ts
@@ -38,6 +38,8 @@ class OutputCoordinator {
 
     // Attempt to parse JSON for structured formats
     try {
+      const parsed = JSON.parse(raw);
+      return this.formatter.to(options.format, parsed);
     } catch (err) {
       console.error('Failed to parse JSON in OutputCoordinator.process:', err);
       return this.formatter.to(options.format, raw);

--- a/src/core/output/stream-processor.ts
+++ b/src/core/output/stream-processor.ts
@@ -14,8 +14,14 @@ class StreamProcessor extends EventEmitter {
   async process(readable: Readable, onChunk?: (chunk: Buffer) => void): Promise<void> {
     const handler = onChunk ?? ((chunk: Buffer) => this.emit('chunk', chunk));
 
-    for await (const chunk of readable) {
-      handler(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    try {
+      for await (const chunk of readable) {
+        handler(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+    } catch (err: any) {
+      if (err?.code !== 'ERR_STREAM_DESTROYED') {
+        throw err;
+      }
     }
 
     this.emit('end');

--- a/src/core/output/truncation-manager.ts
+++ b/src/core/output/truncation-manager.ts
@@ -31,9 +31,7 @@ class TruncationManager {
       return { text: chunk, done: false };
     }
 
-    const truncationMessage = '\n[Truncated]';
-    const text = chunk.slice(0, remaining) + truncationMessage;
-    this.size = text.length;
+    this.size = remaining + truncationMessage.length;
     this.truncated = true;
     return { text, done: true };
   }

--- a/src/core/output/truncation-manager.ts
+++ b/src/core/output/truncation-manager.ts
@@ -31,7 +31,10 @@ class TruncationManager {
       return { text: chunk, done: false };
     }
 
+    const truncationMessage = '\n[Truncated]';
+    const text = chunk.slice(0, remaining) + truncationMessage;
     this.size = text.length;
+    this.truncated = true;
     return { text, done: true };
   }
 


### PR DESCRIPTION
## Summary
- swallow stream destroy errors to return truncated output
- fix size calculation and add truncation marker
- add YAML dependency check and cleaner markdown formatting

## Testing
- `npm run lint:fix` *(fails: 29 errors, 391 warnings)*
- `npm run format` *(fails: SyntaxError in perspective-synthesizer.ts)*
- `npm run typecheck` *(fails: TS1128 in perspective-synthesizer.ts)*
- `npm test` *(fails: missing modules and failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b639fc2d68832d8d3a90e4b1e7efcb