### PR TITLE
fix(mcp): remove undefined module calls

### DIFF
--- a/src/core/mcp/enhanced-mcp-security-system.ts
+++ b/src/core/mcp/enhanced-mcp-security-system.ts
@@ -551,6 +551,20 @@ export class EnhancedMCPSecuritySystem extends EventEmitter {
   }
 
   /**
+   * Validate request data against security policies
+   */
+  async validateRequest(requestData: any): Promise<any> {
+    const policy = this.securityPolicies.get('default');
+    if (policy) {
+      const result = await this.validateInput(policy, requestData);
+      if (!result.valid) {
+        throw new Error(`Request failed security validation: ${result.violations.join(', ')}`);
+      }
+    }
+    return requestData;
+  }
+
+  /**
    * Filter response data
    */
   async filterResponse(connectionId: string, responseData: any): Promise<any> {

--- a/src/core/mcp/mcp-voice-coordinator.ts
+++ b/src/core/mcp/mcp-voice-coordinator.ts
@@ -19,6 +19,7 @@ import { contextTranslator, ContextTranslator } from './context-translator.js';
 import { responseSynthesizer, ResponseSynthesizer } from './response-synthesizer.js';
 import { integrationMonitor, IntegrationMonitor } from './integration-monitor.js';
 import { intelligentMCPLoadBalancer } from './intelligent-mcp-load-balancer.js';
+import { enhancedMCPSecuritySystem } from './enhanced-mcp-security-system.js';
 
 export interface MCPVoiceRequest {
   requestId: string;
@@ -77,8 +78,8 @@ export class MCPVoiceCoordinator extends EventEmitter {
       }
       this.logger.debug('Selected connection', { decision });
 
-      // Placeholder: security and reliability checks
-      const safeContext = mcpContext; // TODO integrate security and reliability systems
+      // Security validation
+      const safeContext = await enhancedMCPSecuritySystem.validateRequest(mcpContext);
 
       // Placeholder: execute tools (not yet implemented)
       const mcpResults = tools.map(tool => ({


### PR DESCRIPTION
## Summary
- import intelligent load balancer and remove references to undefined modules in voice coordinator
- stub load balancer selection using existing `getConnection` and replace security placeholder with safe context
- add `capability` field to `MCPVoiceRequest` and restore request validation through `enhancedMCPSecuritySystem`

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run format`
- `npm run typecheck` *(fails: Cannot find type definition file for '@types/node' and 'jest')*
- `npm test` *(fails: Cannot find module 'node_modules/jest/bin/jest.js')*


------
https://chatgpt.com/codex/tasks/task_e_68b63a3c78a4832dbd52bffd7f84a6ef