### PR TITLE
fix(config): handle voice defaults and watcher errors

### DIFF
--- a/src/domain/config/config-hierarchy.ts
+++ b/src/domain/config/config-hierarchy.ts
@@ -2,6 +2,7 @@ import { homedir } from 'os';
 import { join } from 'path';
 import type { UnifiedConfiguration } from '../interfaces/configuration.js';
 import { loadConfigFile } from './config-loader.js';
+import { validateConfiguration } from './config-validator.js';
 
 export function getDefaultConfig(): UnifiedConfiguration {
   return {
@@ -43,6 +44,7 @@ export function getDefaultConfig(): UnifiedConfiguration {
     },
     voice: {
       enabled: true,
+      availableVoices: ['explorer'],
       defaultVoices: ['explorer'],
       maxConcurrentVoices: 1,
       consensusThreshold: 1,
@@ -190,5 +192,9 @@ export async function resolveConfig(filePath: string): Promise<UnifiedConfigurat
   config = mergeConfigurations(config, fileConfig);
   config = mergeConfigurations(config, loadEnvConfig());
   config = mergeConfigurations(config, loadCliConfig());
+  const validation = validateConfiguration(config);
+  if (!validation.isValid) {
+    throw new Error(`Invalid configuration: ${validation.errors.map(e => e.message).join(', ')}`);
+  }
   return config;
 }

--- a/src/domain/config/config-loader.ts
+++ b/src/domain/config/config-loader.ts
@@ -1,6 +1,5 @@
 import { dirname } from 'path';
 import type { UnifiedConfiguration } from '../interfaces/configuration.js';
-import { validateConfiguration } from './config-validator.js';
 
 export async function loadConfigFile(filePath: string): Promise<Partial<UnifiedConfiguration>> {
   try {
@@ -8,12 +7,7 @@ export async function loadConfigFile(filePath: string): Promise<Partial<UnifiedC
     const { default: YAML } = await import('yaml');
     await access(filePath);
     const content = await readFile(filePath, 'utf-8');
-    const parsed = YAML.parse(content) as Partial<UnifiedConfiguration>;
-    const validation = validateConfiguration(parsed);
-    if (!validation.isValid) {
-      throw new Error(`Invalid configuration: ${validation.errors.map(e => e.message).join(', ')}`);
-    }
-    return parsed;
+    return YAML.parse(content) as Partial<UnifiedConfiguration>;
   } catch (err) {
     console.error(`Failed to load config file "${filePath}":`, err);
     return {};

--- a/src/domain/config/config-watcher.ts
+++ b/src/domain/config/config-watcher.ts
@@ -10,11 +10,11 @@ export class ConfigWatcher {
 
   start(): void {
     if (this.watcher) return;
-        try {
-          await this.onChange();
-        } catch (error) {
-          console.error('Error in ConfigWatcher onChange callback:', error);
-        }
+    this.watcher = watch(this.filePath, async () => {
+      try {
+        await this.onChange();
+      } catch (error) {
+        console.error('Error in ConfigWatcher onChange callback:', error);
       }
     });
   }


### PR DESCRIPTION
## Summary
- ensure `voice.availableVoices` is defined in default configuration
- validate merged configuration after applying file, env, and CLI layers
- log config load failures and harden file watcher callback

## Testing
- `npx eslint src/domain/config/config-hierarchy.ts src/domain/config/config-loader.ts src/domain/config/config-watcher.ts --fix` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck` *(fails: Cannot find type definition file for '@types/node' and 'jest')*
- `npm test` *(fails: Cannot find module 'node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b63a62ba38832d96dd965352483f52