### PR TITLE
fix(mcp): replace magic default pool id with constant

### DIFF
--- a/src/core/mcp/mcp-voice-coordinator.ts
+++ b/src/core/mcp/mcp-voice-coordinator.ts
@@ -39,6 +39,7 @@ export interface MCPVoiceResult {
 
 export class MCPVoiceCoordinator extends EventEmitter {
   private readonly logger = createLogger('MCPVoiceCoordinator');
+  private readonly DEFAULT_POOL_ID = process.env.MCP_DEFAULT_POOL_ID || 'default';
 
   constructor(
     private readonly tools: VoiceToolMapper = voiceToolMapper,
@@ -72,7 +73,7 @@ export class MCPVoiceCoordinator extends EventEmitter {
 
       // Placeholder: choose connection via discovery/load balancer
       const decision = await intelligentMCPLoadBalancer.getConnection(
-        'default',
+        this.DEFAULT_POOL_ID,
         [request.capability],
         request.requestId,
         mcpContext
@@ -86,7 +87,9 @@ export class MCPVoiceCoordinator extends EventEmitter {
       try {
         const validationResult = enhancedMCPSecuritySystem.validateRequest(mcpContext);
         if (validationResult === false) {
-          throw new Error('Security validation failed: validateRequest returned false for the provided context.');
+          throw new Error(
+            'Security validation failed: validateRequest returned false for the provided context.'
+          );
         }
       } catch (err) {
         throw new Error(

--- a/src/core/mcp/mcp-voice-coordinator.ts
+++ b/src/core/mcp/mcp-voice-coordinator.ts
@@ -87,8 +87,7 @@ export class MCPVoiceCoordinator extends EventEmitter {
       try {
         const validationResult = enhancedMCPSecuritySystem.validateRequest(mcpContext);
         if (validationResult === false) {
-          throw new Error(
-            'Security validation failed: validateRequest returned false for the provided context.'
+            `Security validation failed for requestId=${request.requestId}, voiceId=${request.voiceId}, capability=${request.capability}: validateRequest returned false for the provided context.`
           );
         }
       } catch (err) {


### PR DESCRIPTION
## Summary
- avoid magic string when selecting load balancer connection pool
- clarify security validation error message

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run format`
- `npm run typecheck` *(fails: Cannot find type definition file for '@types/node')*
- `npm test` *(fails: Cannot find module 'node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b63ac0c6ec832d9fa6da9b4eefa781