### PR TITLE
fix: keep voice coordinator initialize async

### DIFF
--- a/src/voices/voice-system-coordinator.ts
+++ b/src/voices/voice-system-coordinator.ts
@@ -33,10 +33,11 @@ export class VoiceSystemCoordinator implements VoiceArchetypeSystemInterface {
     this.council = new CouncilOrchestrator(
       new CouncilDecisionEngine(this as VoiceArchetypeSystemInterface, modelClient)
     );
-    // NOTE: Call initialize() explicitly after construction.
+    // NOTE: Call initialize() explicitly after construction (await if needed).
   }
 
-  initialize(): void {
+  async initialize(): Promise<void> {
+    // All operations are synchronous; method remains async for API compatibility.
     const context = this.buildContext();
     this.voices = createArchetypeDefinitions(context);
   }


### PR DESCRIPTION
## Summary
- restore async initialize method for VoiceSystemCoordinator
- document explicit post-construction initialization with synchronous operations

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm run format` *(fails: SyntaxError: Declaration or statement expected in perspective-synthesizer.ts)*
- `npm run typecheck` *(fails: Declaration or statement expected in perspective-synthesizer.ts)*
- `npm test` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b63ae47964832dad39241f5ed56a82