### PR TITLE
fix: address review comments in output modules

### DIFF
--- a/src/core/output/output-coordinator.ts
+++ b/src/core/output/output-coordinator.ts
@@ -37,13 +37,14 @@ class OutputCoordinator {
     }
 
     // Attempt to parse JSON for structured formats
+    let data: unknown = raw;
     try {
-      const parsed = JSON.parse(raw);
-      return this.formatter.to(options.format, parsed);
+      data = JSON.parse(raw);
     } catch (err) {
       console.error('Failed to parse JSON in OutputCoordinator.process:', err);
-      return this.formatter.to(options.format, raw);
     }
+
+    return this.formatter.to(options.format, data);
   }
 }
 

--- a/src/core/output/stream-processor.ts
+++ b/src/core/output/stream-processor.ts
@@ -2,6 +2,10 @@ import { Readable } from 'stream';
 import { EventEmitter } from 'events';
 import { outputConfig } from '../../utils/output-config.js';
 
+function hasCode(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && typeof (err as { code?: unknown }).code === 'string';
+}
+
 /**
  * StreamProcessor handles true streaming of data sources using Node streams.
  * It emits chunks as they arrive without buffering the entire content.
@@ -18,8 +22,8 @@ class StreamProcessor extends EventEmitter {
       for await (const chunk of readable) {
         handler(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
       }
-    } catch (err: any) {
-      if (err?.code !== 'ERR_STREAM_DESTROYED') {
+    } catch (err: unknown) {
+      if (!hasCode(err) || err.code !== 'ERR_STREAM_DESTROYED') {
         throw err;
       }
     }

--- a/src/core/output/truncation-manager.ts
+++ b/src/core/output/truncation-manager.ts
@@ -1,5 +1,7 @@
 import { outputConfig } from '../../utils/output-config.js';
 
+const TRUNCATION_MESSAGE = '\n[...output truncated...]\n';
+
 /**
  * TruncationManager enforces memory-safe limits on streamed content.
  * It tracks cumulative size and truncates with a clear marker when limits are exceeded.
@@ -31,7 +33,8 @@ class TruncationManager {
       return { text: chunk, done: false };
     }
 
-    this.size = remaining + truncationMessage.length;
+    const text = chunk.slice(0, remaining) + TRUNCATION_MESSAGE;
+    this.size = remaining + TRUNCATION_MESSAGE.length;
     this.truncated = true;
     return { text, done: true };
   }

--- a/src/core/output/truncation-manager.ts
+++ b/src/core/output/truncation-manager.ts
@@ -33,8 +33,7 @@ class TruncationManager {
       return { text: chunk, done: false };
     }
 
-    const text = chunk.slice(0, remaining) + TRUNCATION_MESSAGE;
-    this.size = remaining + TRUNCATION_MESSAGE.length;
+    this.size = text.length;
     this.truncated = true;
     return { text, done: true };
   }


### PR DESCRIPTION
## Summary
- handle JSON parsing with fallback in OutputCoordinator
- correct truncation marker and size calculation
- replace unsafe `any` with type guard in StreamProcessor

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: SyntaxError in perspective-synthesizer.ts)*
- `npm run typecheck` *(fails: TS1128 in perspective-synthesizer.ts)*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68b63bddcad8832d87c206f060608d90