### PR TITLE
refactor: inject logger into ServiceFactory and dispose runtime context

### DIFF
--- a/src/application/runtime/runtime-context.ts
+++ b/src/application/runtime/runtime-context.ts
@@ -45,3 +45,25 @@ export function createRuntimeContext(opts: CreateRuntimeContextOptions): Runtime
 export function createTestRuntimeContext(eventBus: IEventBus): RuntimeContext {
   return createRuntimeContext({ eventBus });
 }
+
+/**
+ * Dispose a runtime context and release underlying resources
+ */
+export async function disposeRuntimeContext(context: RuntimeContext): Promise<void> {
+  // Remove all event listeners to avoid leaks between tests or runs
+  context.eventBus.removeAllListeners();
+
+  // Attempt to dispose the resource coordinator if it provides a dispose method
+  const coordinator: any = context.resourceCoordinator as any;
+  if (typeof coordinator?.dispose === 'function') {
+    await coordinator.dispose();
+  } else if (typeof coordinator?.removeAllListeners === 'function') {
+    coordinator.removeAllListeners();
+  }
+
+  // Clean up configuration manager listeners if present
+  const configManager: any = context.configManager;
+  if (typeof configManager?.removeAllListeners === 'function') {
+    configManager.removeAllListeners();
+  }
+}

--- a/src/application/services/service-factory.ts
+++ b/src/application/services/service-factory.ts
@@ -4,7 +4,11 @@
  * Part of architectural debt remediation
  */
 
-import { RuntimeContext, createRuntimeContext } from '../runtime/runtime-context.js';
+import {
+  RuntimeContext,
+  createRuntimeContext,
+  disposeRuntimeContext,
+} from '../runtime/runtime-context.js';
 import {
   UnifiedOrchestrationService,
   createUnifiedOrchestrationServiceWithContext,
@@ -18,6 +22,7 @@ import {
   ResourceCoordinatorFactory,
 } from '../../infrastructure/performance/configurable-resource-coordinator.js';
 import { createLogger } from '../../infrastructure/logging/logger-adapter.js';
+import type { ILogger } from '../../domain/interfaces/logger.js';
 import { CLIUserInteraction } from '../../infrastructure/user-interaction/cli-user-interaction.js';
 import { EventBus } from '../../infrastructure/messaging/event-bus.js';
 
@@ -41,7 +46,10 @@ export class ServiceFactory {
   private configManager?: UnifiedConfigurationManager;
   private resourceCoordinator?: ConfigurableResourceCoordinator;
 
-  constructor(private config: ServiceFactoryConfig = {}) {
+  constructor(
+    private config: ServiceFactoryConfig = {},
+    private logger: ILogger = createLogger('ServiceFactory')
+  ) {
     this.runtimeContext = createRuntimeContext({
       eventBus: new EventBus(),
     });
@@ -76,14 +84,14 @@ export class ServiceFactory {
    */
   async createConfigurationManager(): Promise<UnifiedConfigurationManager> {
     if (!this.configManager) {
-      const logger = createLogger('ConfigurationManager'); // TODO: Get logger from context
       const eventBus = this.runtimeContext.eventBus;
 
       this.configManager = await createUnifiedConfigurationManager({
-        logger,
+        logger: this.logger,
         configFilePath: this.config.configFilePath,
         eventBus,
       });
+      this.runtimeContext.configManager = this.configManager;
     }
     return this.configManager;
   }
@@ -118,13 +126,14 @@ export class ServiceFactory {
    */
   async dispose(): Promise<void> {
     if (this.resourceCoordinator) {
-      // ConfigurableResourceCoordinator doesn't have shutdown method in current implementation
-      // Just clean up reference
+      if (typeof this.resourceCoordinator.dispose === 'function') {
+        await this.resourceCoordinator.dispose();
+      }
       this.resourceCoordinator = undefined;
     }
 
-    // TODO: Implement proper cleanup for RuntimeContext
-    // await this.runtimeContext.dispose();
+    await disposeRuntimeContext(this.runtimeContext);
+    this.configManager = undefined;
   }
 
   // Private helper methods

--- a/tests/unit/application/service-factory-disposal.test.ts
+++ b/tests/unit/application/service-factory-disposal.test.ts
@@ -1,0 +1,35 @@
+import { ServiceFactory } from '../../../src/application/services/service-factory.js';
+import type { ILogger } from '../../../src/domain/interfaces/logger.js';
+
+describe('ServiceFactory disposal', () => {
+  function createTestLogger(): ILogger {
+    return {
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      trace: jest.fn(),
+    };
+  }
+
+  it('disposes runtime context resources and resource coordinator', async () => {
+    const logger = createTestLogger();
+    const factory = new ServiceFactory({}, logger);
+    const context = factory.getRuntimeContext();
+
+    const handler = jest.fn();
+    context.eventBus.on('test-event', handler);
+
+    const coordinator = await factory.createResourceCoordinator();
+    const disposeSpy = jest.spyOn(coordinator, 'dispose');
+    const configManager = await factory.createConfigurationManager();
+    const configListener = jest.fn();
+    configManager.on('config-test', configListener);
+
+    await factory.dispose();
+
+    expect(disposeSpy).toHaveBeenCalled();
+    expect(context.eventBus.listenerCount('test-event')).toBe(0);
+    expect(configManager.listenerCount('config-test')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- inject logger into `ServiceFactory` via constructor and remove direct logger creation
- add `disposeRuntimeContext` helper to clean up event bus and related resources
- cover `ServiceFactory` cleanup with a unit test

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npx prettier --write src/application/runtime/runtime-context.ts src/application/services/service-factory.ts tests/unit/application/service-factory-disposal.test.ts`
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest')*
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*


------
https://chatgpt.com/codex/tasks/task_e_68b76f04f730832dbb130d9fef8aabf9