### PR TITLE
refactor: inject logger into ServiceFactory and dispose runtime context

### DIFF
--- a/src/application/services/service-factory.ts
+++ b/src/application/services/service-factory.ts
@@ -8,6 +8,7 @@ import {
   RuntimeContext,
   createRuntimeContext,
   disposeRuntimeContext,
+  setConfigManager,
 } from '../runtime/runtime-context.js';
 import {
   UnifiedOrchestrationService,
@@ -91,7 +92,7 @@ export class ServiceFactory {
         configFilePath: this.config.configFilePath,
         eventBus,
       });
-      this.runtimeContext.configManager = this.configManager;
+      setConfigManager(this.runtimeContext, this.configManager);
     }
     return this.configManager;
   }


### PR DESCRIPTION
## Summary
- prevent disposing the shared `unifiedResourceCoordinator` when cleaning up runtime context
- add `setConfigManager` helper and use type guards instead of `any`
- update `ServiceFactory` to assign config manager via helper

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: SyntaxError: 'catch' or 'finally' expected)*
- `npm run typecheck` *(fails: 'catch' or 'finally' expected)*
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*


------
https://chatgpt.com/codex/tasks/task_e_68b772de8a00832dadcbe6b3fe7a4347