### PR TITLE
fix: validate package names and normalize install output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,7 @@
         "terminal-link": "^3.0.0",
         "tree-kill": "^1.2.2",
         "update-notifier": "^7.0.0",
+        "validate-npm-package-name": "^5.0.1",
         "winston": "^3.17.0",
         "wrap-ansi": "^9.0.0",
         "yaml": "^2.8.1",
@@ -134,6 +135,7 @@
         "@types/node": "^20.19.0",
         "@types/socket.io": "^3.0.1",
         "@types/tar": "^6.1.13",
+        "@types/validate-npm-package-name": "^3.0.3",
         "@types/ws": "^8.5.0",
         "@typescript-eslint/eslint-plugin": "^6.19.0",
         "@typescript-eslint/parser": "^6.19.0",
@@ -2661,6 +2663,24 @@
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.7.0.tgz",
       "integrity": "sha512-qn6tAIZEw5i/wiESBF4nQxZkl86aY4KoO0IkUa2Lh+rya64oTOdJQFlZuMwI1Qz9VBJQrQC4QlSA2DNek5gCOA==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@codecrucible/rust-executor-darwin-arm64": {
+      "optional": true
+    },
+    "node_modules/@codecrucible/rust-executor-darwin-x64": {
+      "optional": true
+    },
+    "node_modules/@codecrucible/rust-executor-linux-arm64-gnu": {
+      "optional": true
+    },
+    "node_modules/@codecrucible/rust-executor-linux-x64-gnu": {
+      "optional": true
+    },
+    "node_modules/@codecrucible/rust-executor-linux-x64-musl": {
+      "optional": true
+    },
+    "node_modules/@codecrucible/rust-executor-win32-x64-msvc": {
+      "optional": true
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -9741,6 +9761,13 @@
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/validate-npm-package-name": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-3.0.3.tgz",
+      "integrity": "sha512-dLhCHEIjf9++/vHaHCo/ngJzGqGGbPh/f7HKwznEk3WFL64t/VKuRiVpyQH4afX93YkCV94I9M0Cx+DBLk1Dsg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/verror": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test-install": "node scripts/install-and-test.js",
     "package:bundle": "ncc build dist/index.js -o build/bundled",
     "package:win": "npm run package:bundle && npm run desktop:package:win",
-    "package:mac": "npm run package:bundle && npm run desktop:package:mac", 
+    "package:mac": "npm run package:bundle && npm run desktop:package:mac",
     "package:linux": "npm run package:bundle && npm run desktop:package:linux",
     "package:all": "npm run package:win && npm run package:mac && npm run package:linux",
     "desktop:package": "electron-builder",
@@ -196,6 +196,7 @@
     "terminal-link": "^3.0.0",
     "tree-kill": "^1.2.2",
     "update-notifier": "^7.0.0",
+    "validate-npm-package-name": "^5.0.1",
     "winston": "^3.17.0",
     "wrap-ansi": "^9.0.0",
     "yaml": "^2.8.1",
@@ -219,6 +220,7 @@
     "@types/node": "^20.19.0",
     "@types/socket.io": "^3.0.1",
     "@types/tar": "^6.1.13",
+    "@types/validate-npm-package-name": "^3.0.3",
     "@types/ws": "^8.5.0",
     "@typescript-eslint/eslint-plugin": "^6.19.0",
     "@typescript-eslint/parser": "^6.19.0",
@@ -239,11 +241,7 @@
     "directories": {
       "output": "build/desktop"
     },
-    "files": [
-      "dist/**/*",
-      "config/**/*",
-      "node_modules/**/*"
-    ],
+    "files": ["dist/**/*", "config/**/*", "node_modules/**/*"],
     "mac": {
       "category": "public.app-category.developer-tools"
     },
@@ -274,11 +272,11 @@
     }
   },
   "optionalDependencies": {
-    "@codecrucible/rust-executor-win32-x64-msvc": "*",
-    "@codecrucible/rust-executor-darwin-x64": "*",
     "@codecrucible/rust-executor-darwin-arm64": "*",
-    "@codecrucible/rust-executor-linux-x64-gnu": "*",
+    "@codecrucible/rust-executor-darwin-x64": "*",
     "@codecrucible/rust-executor-linux-arm64-gnu": "*",
-    "@codecrucible/rust-executor-linux-x64-musl": "*"
+    "@codecrucible/rust-executor-linux-x64-gnu": "*",
+    "@codecrucible/rust-executor-linux-x64-musl": "*",
+    "@codecrucible/rust-executor-win32-x64-msvc": "*"
   }
 }

--- a/src/@types/validate-npm-package-name.d.ts
+++ b/src/@types/validate-npm-package-name.d.ts
@@ -1,0 +1,10 @@
+declare module 'validate-npm-package-name' {
+  interface ValidationResult {
+    validForNewPackages: boolean;
+    validForOldPackages: boolean;
+    errors?: string[];
+    warnings?: string[];
+  }
+  function validate(name: string): ValidationResult;
+  export default validate;
+}

--- a/src/mcp-servers/package-manager-server.ts
+++ b/src/mcp-servers/package-manager-server.ts
@@ -9,6 +9,7 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 import * as path from 'path';
 import * as fs from 'fs/promises';
+import validatePackageName from 'validate-npm-package-name';
 import { logger } from '../infrastructure/logging/logger.js';
 
 const execFileAsync = promisify(execFile);
@@ -41,7 +42,7 @@ interface PackageJson {
 
 export class PackageManagerMCPServer {
   private server: Server;
-  private config: PackageManagerConfig;
+  private config: Required<PackageManagerConfig>;
   private initialized = false;
 
   constructor(config: PackageManagerConfig = {}) {
@@ -102,10 +103,11 @@ export class PackageManagerMCPServer {
 
       switch (name) {
         case 'install_package': {
-          const result = await this.installPackage(
-            (args as InstallPackageArgs).name,
-            (args as InstallPackageArgs).manager
-          );
+          const installArgs = args as InstallPackageArgs | undefined;
+          if (!installArgs) {
+            throw new Error("Missing arguments for 'install_package'");
+          }
+          const result = await this.installPackage(installArgs.name, installArgs.manager);
           return {
             content: [{ type: 'text', text: result.stdout || result.stderr || '' }],
           };
@@ -167,24 +169,28 @@ export class PackageManagerMCPServer {
   }
 
   private async installPackage(name: string, manager?: string): Promise<InstallPackageResult> {
-    const pkgManager = manager || this.config.defaultManager!;
-    if (!this.config.allowedManagers!.includes(pkgManager)) {
+    const pkgManager = manager || this.config.defaultManager;
+    if (!pkgManager || !this.config.allowedManagers.includes(pkgManager)) {
       throw new Error(`Package manager ${pkgManager} not allowed`);
     }
 
-    if (!/^[\w@./-]+$/.test(name)) {
+    const atIndex = name.indexOf('@', 1);
+    const pkgName = atIndex > -1 ? name.slice(0, atIndex) : name;
+    const validation = validatePackageName(pkgName);
+    if (!validation.validForNewPackages && !validation.validForOldPackages) {
       throw new Error(`Invalid package name: ${name}`);
     }
 
     const { stdout, stderr } = await execFileAsync(pkgManager, ['install', name], {
       cwd: this.config.workingDirectory,
+      encoding: 'utf8',
     });
 
     return { stdout, stderr };
   }
 
   private async listInstalled(): Promise<ListInstalledResult> {
-    const pkgPath = path.join(this.config.workingDirectory!, 'package.json');
+    const pkgPath = path.join(this.config.workingDirectory, 'package.json');
     let file: string;
     let pkg: PackageJson;
     try {


### PR DESCRIPTION
## Summary
- allow scoped and versioned package specs using `validate-npm-package-name`
- ensure `install_package` args exist and return UTF-8 strings from execFile
- add module typings for `validate-npm-package-name`

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npx prettier src/mcp-servers/package-manager-server.ts src/@types/validate-npm-package-name.d.ts package.json package-lock.json --write`
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest' and 'node')*
- `npm test` *(fails: Cannot find module '/workspace/codecrucible-synth/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b774a472cc832db1487fdd3761f80e