### PR TITLE
fix: handle worker pool lifecycle and failures

### DIFF
--- a/src/application/cli/analysis-worker-pool.ts
+++ b/src/application/cli/analysis-worker-pool.ts
@@ -13,17 +13,48 @@ export class AnalysisWorkerPool {
   private available: Worker[] = [];
   private queue: { task: any; resolve: (v: any) => void; reject: (r: any) => void }[] = [];
   private callbacks = new Map<string, PendingTask>();
+  private activeTasks = new Map<Worker, string>();
+  private workerPath: string;
 
   constructor(size = 2) {
     // Use .ts for development (ts-node), .js for production (compiled)
     const ext = fileURLToPath(import.meta.url).endsWith('.ts') ? '.ts' : '.js';
-    const workerPath = join(dirname(fileURLToPath(import.meta.url)), `analysis-worker${ext}`);
+    this.workerPath = join(dirname(fileURLToPath(import.meta.url)), `analysis-worker${ext}`);
     for (let i = 0; i < size; i++) {
-      const worker = new Worker(workerPath, { type: 'module' });
-      worker.on('message', msg => this.handleMessage(worker, msg));
-      this.workers.push(worker);
-      this.available.push(worker);
+      this.spawnWorker();
     }
+  }
+
+  private spawnWorker(): void {
+    const worker = new Worker(this.workerPath, { type: 'module' });
+    worker.on('message', msg => this.handleMessage(worker, msg));
+    worker.on('error', err => this.handleFailure(worker, err));
+    worker.on('exit', code => {
+      if (code !== 0) {
+        this.handleFailure(worker, new Error(`Worker exited with code ${code}`));
+      }
+    });
+    worker.unref();
+    this.workers.push(worker);
+    this.available.push(worker);
+  }
+
+  private handleFailure(worker: Worker, err: Error): void {
+    const taskId = this.activeTasks.get(worker);
+    if (taskId) {
+      const cb = this.callbacks.get(taskId);
+      cb?.reject(err);
+      this.callbacks.delete(taskId);
+      this.activeTasks.delete(worker);
+    }
+    this.removeWorker(worker);
+    this.spawnWorker();
+    this.processQueue();
+  }
+
+  private removeWorker(worker: Worker): void {
+    this.workers = this.workers.filter(w => w !== worker);
+    this.available = this.available.filter(w => w !== worker);
   }
 
   private handleMessage(worker: Worker, msg: any): void {
@@ -42,11 +73,12 @@ export class AnalysisWorkerPool {
 
   private processQueue(): void {
     if (this.queue.length === 0 || this.available.length === 0) return;
-    const worker = this.available.shift();
+    const worker = this.available.shift()!;
     const { task, resolve, reject } = this.queue.shift()!;
     const id = randomUUID();
     this.callbacks.set(id, { resolve, reject });
-    worker?.postMessage({ ...task, id });
+    this.activeTasks.set(worker, id);
+    worker.postMessage({ ...task, id });
   }
 
   runTask(task: any): Promise<any> {
@@ -60,6 +92,7 @@ export class AnalysisWorkerPool {
     await Promise.all(this.workers.map(w => w.terminate()));
     this.workers = [];
     this.available = [];
+    this.activeTasks.clear();
   }
 }
 

--- a/src/application/cli/analysis-worker.ts
+++ b/src/application/cli/analysis-worker.ts
@@ -1,6 +1,10 @@
 import { parentPort } from 'worker_threads';
 
 parentPort?.on('message', async (task: any) => {
+  if (task.crash) {
+    // Simulate an unexpected failure for testing purposes
+    process.exit(1);
+  }
   try {
     const delay = typeof task.delay === 'number' ? task.delay : 0;
     await new Promise(resolve => setTimeout(resolve, delay));

--- a/tests/unit/application/cli/analysis-worker-pool.test.ts
+++ b/tests/unit/application/cli/analysis-worker-pool.test.ts
@@ -12,4 +12,12 @@ describe('AnalysisWorkerPool', () => {
     await pool.destroy();
     expect(duration).toBeLessThan(180);
   });
+
+  it('recovers from worker failure', async () => {
+    const pool = new AnalysisWorkerPool(1);
+    await expect(pool.runTask({ crash: true })).rejects.toThrow();
+    const result = await pool.runTask({ files: ['c'], delay: 10 });
+    await pool.destroy();
+    expect(result.totalFiles).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure analysis worker pool doesn't block process exit and recovers from worker errors
- allow tests to simulate worker crashes
- add unit test covering worker failure recovery

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run format`
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest', 'node')*
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*


------
https://chatgpt.com/codex/tasks/task_e_68b774cd193c832da38a728a3a1f2a86