### PR TITLE
refactor: centralize provider setup and modularize tools

### DIFF
--- a/src/application/services/client.ts
+++ b/src/application/services/client.ts
@@ -25,7 +25,7 @@ export function createDefaultUnifiedClientConfig(): UnifiedClientConfig {
   return {
     providers,
     executionMode: 'auto' as const,
-    fallbackChain: fallbackChain as any,
+    fallbackChain,
     performanceThresholds: {
       fastModeMaxTokens: 1000,
       timeoutMs: 30000,

--- a/src/application/services/client.ts
+++ b/src/application/services/client.ts
@@ -11,23 +11,21 @@ export {
 
 // Use the local UnifiedClientConfig from types.ts
 import type { UnifiedClientConfig } from '../../domain/types/index.js';
+import { defaultProviderRegistry } from '../../providers/provider-registry.js';
 export type { UnifiedClientConfig } from '../../domain/types/index.js';
 
 // Export a default config creator function
 export function createDefaultUnifiedClientConfig(): UnifiedClientConfig {
+  const fallbackChain = defaultProviderRegistry.getFallbackChain();
+  const providers = fallbackChain
+    .map(p => defaultProviderRegistry.getProvider(p))
+    .filter((p): p is NonNullable<typeof p> => !!p)
+    .map(p => ({ type: p.name, endpoint: p.endpoint }));
+
   return {
-    providers: [
-      {
-        type: 'ollama',
-        endpoint: 'http://localhost:11434',
-      },
-      {
-        type: 'lm-studio',
-        endpoint: 'ws://localhost:8080',
-      },
-    ],
+    providers,
     executionMode: 'auto' as const,
-    fallbackChain: ['ollama', 'lm-studio', 'auto'] as const,
+    fallbackChain: fallbackChain as any,
     performanceThresholds: {
       fastModeMaxTokens: 1000,
       timeoutMs: 30000,

--- a/src/infrastructure/tools/path-normalizer.ts
+++ b/src/infrastructure/tools/path-normalizer.ts
@@ -5,10 +5,10 @@ import { PathUtilities } from '../../utils/path-utilities.js';
  * Normalize file paths using centralized PathUtilities.
  * Extracted from ToolIntegration for reuse and easier testing.
  */
-export function normalizePath(filePath: string, logger: ILogger): string {
+export function normalizePath(filePath: unknown, logger: ILogger): string | unknown {
   if (typeof filePath !== 'string') {
     logger.debug('[PATH DEBUG] Non-string path, using as-is:', filePath);
-    return filePath as any;
+    return filePath;
   }
 
   logger.debug(`[PATH DEBUG] Original path: "${filePath}"`);

--- a/src/infrastructure/tools/path-normalizer.ts
+++ b/src/infrastructure/tools/path-normalizer.ts
@@ -1,0 +1,38 @@
+import type { ILogger } from '../../domain/interfaces/logger.js';
+import { PathUtilities } from '../../utils/path-utilities.js';
+
+/**
+ * Normalize file paths using centralized PathUtilities.
+ * Extracted from ToolIntegration for reuse and easier testing.
+ */
+export function normalizePath(filePath: string, logger: ILogger): string {
+  if (typeof filePath !== 'string') {
+    logger.debug('[PATH DEBUG] Non-string path, using as-is:', filePath);
+    return filePath as any;
+  }
+
+  logger.debug(`[PATH DEBUG] Original path: "${filePath}"`);
+
+  if (filePath === '/project' || filePath === '/project/' || filePath === 'codecrucible') {
+    logger.debug('[PATH DEBUG] Repository root placeholder detected, converting to "."');
+    return '.';
+  }
+
+  if (filePath.startsWith('/project/') && filePath.length > 9) {
+    const relativePath = filePath.substring(9);
+    logger.debug(
+      `[PATH DEBUG] Extracted relative path from placeholder: "${filePath}" → "${relativePath}"`
+    );
+    filePath = relativePath;
+  }
+
+  const normalizedPath = PathUtilities.normalizeAIPath(filePath, {
+    allowAbsolute: true,
+    allowRelative: true,
+    allowTraversal: false,
+    basePath: process.cwd(),
+  });
+
+  logger.debug(`[PATH DEBUG] Normalized: "${filePath}" → "${normalizedPath}"`);
+  return normalizedPath;
+}

--- a/src/infrastructure/tools/risk-scorer.ts
+++ b/src/infrastructure/tools/risk-scorer.ts
@@ -1,0 +1,23 @@
+/**
+ * Simple heuristics for estimating risk level and duration of tool calls.
+ * Extracted from ToolIntegration for reuse.
+ */
+export function inferRiskLevel(functionName: string): 'low' | 'medium' | 'high' | 'critical' {
+  if (
+    functionName.includes('write') ||
+    functionName.includes('execute') ||
+    functionName.includes('command')
+  ) {
+    return 'high';
+  }
+  if (functionName.includes('git') || functionName.includes('npm')) {
+    return 'medium';
+  }
+  return 'low';
+}
+
+export function inferDuration(functionName: string): number {
+  if (functionName.includes('npm') || functionName.includes('execute')) return 5000; // 5 seconds
+  if (functionName.includes('git')) return 2000; // 2 seconds
+  return 1000; // 1 second default
+}

--- a/src/infrastructure/tools/tool-integration.ts
+++ b/src/infrastructure/tools/tool-integration.ts
@@ -165,8 +165,8 @@ export class ToolIntegration {
           name: tool.function.name,
           description: tool.function.description,
           inputSchema: {
-            properties: tool.function.parameters.properties || {},
-            required: tool.function.parameters.required || [],
+            properties: tool.function.parameters?.properties || {},
+            required: tool.function.parameters?.required || [],
           },
           // Execution will be handled by the unified tool system
           handler: null, // Will be resolved during execution

--- a/src/infrastructure/tools/tool-integration.ts
+++ b/src/infrastructure/tools/tool-integration.ts
@@ -6,8 +6,10 @@
 import { MCPServerManager } from '../../mcp-servers/mcp-server-manager.js';
 import { createDefaultToolRegistry, createLegacyToolRegistry } from './default-tool-registry.js';
 import { createLogger } from '../logging/logger-adapter.js';
-import { unifiedToolRegistry, ToolDefinition } from './unified-tool-registry.js';
-import { PathUtilities } from '../../utils/path-utilities.js';
+import { ToolDefinition, unifiedToolRegistry } from './unified-tool-registry.js';
+import { normalizePath } from './path-normalizer.js';
+import { inferDuration, inferRiskLevel } from './risk-scorer.js';
+import { createToolAliasMapping, mapToMcpToolName, resolveToolName } from './tool-mapper.js';
 
 export interface LLMFunction {
   type: 'function';
@@ -30,7 +32,7 @@ export interface ToolCall {
 }
 
 export class ToolIntegration {
-  private mcpManager: MCPServerManager;
+  private readonly mcpManager: MCPServerManager;
   protected availableTools: Map<string, any> = new Map();
   private initializationPromise: Promise<void> | null = null;
   private isInitialized = false;
@@ -47,42 +49,6 @@ export class ToolIntegration {
   }
 
   /**
-   * Normalize file paths using centralized PathUtilities
-   */
-  private normalizePath(filePath: string): string {
-    if (typeof filePath !== 'string') {
-      this.logger.debug(`[PATH DEBUG] Non-string path, using as-is:`, filePath);
-      return filePath;
-    }
-    
-    this.logger.debug(`[PATH DEBUG] Original path: "${filePath}"`);
-    
-    // Handle special AI placeholders first
-    if (filePath === '/project' || filePath === '/project/' || filePath === 'codecrucible') {
-      this.logger.debug(`[PATH DEBUG] Repository root placeholder detected, converting to "."`);
-      return '.';
-    }
-    
-    // Handle placeholder paths like /project/nested/file.txt by extracting the relative part
-    if (filePath.startsWith('/project/') && filePath.length > 9) {
-      const relativePath = filePath.substring(9); // Remove '/project/' prefix
-      this.logger.debug(`[PATH DEBUG] Extracted relative path from placeholder: "${filePath}" → "${relativePath}"`);
-      filePath = relativePath; // Continue with extracted path
-    }
-    
-    // Use centralized path normalization
-    const normalizedPath = PathUtilities.normalizeAIPath(filePath, {
-      allowAbsolute: true,
-      allowRelative: true,
-      allowTraversal: false,
-      basePath: process.cwd()
-    });
-    
-    this.logger.debug(`[PATH DEBUG] Normalized: "${filePath}" → "${normalizedPath}"`);
-    return normalizedPath;
-  }
-
-  /**
    * Infer tool category from function name
    */
   private inferCategory(functionName: string): ToolDefinition['category'] {
@@ -93,118 +59,6 @@ export class ToolIntegration {
     if (functionName.includes('smithery')) return 'external';
     return 'system';
   }
-  
-  /**
-   * Infer risk level from function name  
-   */
-  private inferRiskLevel(functionName: string): 'low' | 'medium' | 'high' | 'critical' {
-    if (functionName.includes('write') || functionName.includes('execute') || functionName.includes('command')) {
-      return 'high';
-    }
-    if (functionName.includes('git') || functionName.includes('npm')) {
-      return 'medium';
-    }
-    return 'low';
-  }
-  
-  /**
-   * Infer estimated duration from function name
-   */
-  private inferDuration(functionName: string): number {
-    if (functionName.includes('npm') || functionName.includes('execute')) return 5000; // 5 seconds
-    if (functionName.includes('git')) return 2000; // 2 seconds  
-    return 1000; // 1 second default
-  }
-
-  /**
-   * Map AI-facing function names to actual MCP tool names
-   */
-  private mapToMcpToolName(functionName: string): string {
-    const mapping: Record<string, string> = {
-      // Filesystem tools
-      'filesystem_read_file': 'read_file',
-      'filesystem_write_file': 'write_file', 
-      'filesystem_list_directory': 'list_directory',
-      'filesystem_get_stats': 'get_stats',
-      // Git tools
-      'git_status': 'git_status',
-      'git_add': 'git_add',
-      'git_commit': 'git_commit',
-      // System tools  
-      'execute_command': 'execute_command',
-      // Package manager tools
-      'npm_install': 'npm_install',
-      'npm_run': 'npm_run',
-      // Smithery tools
-      'smithery_status': 'smithery_status',
-      'smithery_refresh': 'smithery_refresh',
-    };
-
-    return mapping[functionName] || functionName;
-  }
-
-  /**
-   * Create reverse mapping and aliases for tool resolution
-   */
-  private createToolAliasMapping(): Record<string, string> {
-    const aliases: Record<string, string> = {};
-    
-    // Standard aliases for filesystem tools
-    aliases['filesystem_read_file'] = 'filesystem_read_file';
-    aliases['read_file'] = 'filesystem_read_file';
-    
-    aliases['filesystem_write_file'] = 'filesystem_write_file';
-    aliases['write_file'] = 'filesystem_write_file';
-    
-    aliases['filesystem_list_directory'] = 'filesystem_list_directory';
-    aliases['list_directory'] = 'filesystem_list_directory';
-    
-    aliases['filesystem_get_stats'] = 'filesystem_get_stats';
-    aliases['get_stats'] = 'filesystem_get_stats';
-    
-    // Add aliases for all registered tools
-    for (const [toolId] of this.availableTools) {
-      aliases[toolId] = toolId; // Self-mapping
-      
-      // Create short aliases by removing prefixes
-      if (toolId.includes('_')) {
-        const shortName = toolId.split('_').slice(1).join('_');
-        if (shortName) {
-          aliases[shortName] = toolId;
-        }
-      }
-    }
-    
-    return aliases;
-  }
-
-  /**
-   * Resolve tool name through alias mapping
-   */
-  private resolveToolName(functionName: string): string | null {
-    // First check direct match
-    if (this.availableTools.has(functionName)) {
-      return functionName;
-    }
-    
-    // Create and check alias mapping
-    const aliasMapping = this.createToolAliasMapping();
-    const resolvedName = aliasMapping[functionName];
-    
-    if (resolvedName && this.availableTools.has(resolvedName)) {
-      return resolvedName;
-    }
-    
-    // Try the MCP mapping as a fallback
-    const mcpName = this.mapToMcpToolName(functionName);
-    for (const [toolId] of this.availableTools) {
-      if (this.mapToMcpToolName(toolId) === mcpName) {
-        return toolId;
-      }
-    }
-    
-    return null; // Tool not found
-  }
 
   /**
    * Map AI-facing parameter names to MCP server parameter names
@@ -212,47 +66,47 @@ export class ToolIntegration {
   private mapArgsForMcpTool(functionName: string, args: any): any {
     this.logger.info(`[ARGS DEBUG] Mapping args for ${functionName}:`, args);
     const mappedArgs = { ...args };
-    
+
     // Parameter name mappings for different tools
     switch (functionName) {
       case 'filesystem_read_file':
         if (mappedArgs.file_path !== undefined) {
-          mappedArgs.path = this.normalizePath(mappedArgs.file_path);
+          mappedArgs.path = normalizePath(mappedArgs.file_path, this.logger);
           delete mappedArgs.file_path;
         }
         break;
-        
+
       case 'filesystem_write_file':
         if (mappedArgs.file_path !== undefined) {
-          mappedArgs.path = this.normalizePath(mappedArgs.file_path);
+          mappedArgs.path = normalizePath(mappedArgs.file_path, this.logger);
           delete mappedArgs.file_path;
         }
         break;
-        
+
       case 'filesystem_list_directory':
         if (mappedArgs.directory !== undefined) {
-          mappedArgs.path = this.normalizePath(mappedArgs.directory);
+          mappedArgs.path = normalizePath(mappedArgs.directory, this.logger);
           delete mappedArgs.directory;
         }
         break;
-        
+
       case 'filesystem_get_stats':
         if (mappedArgs.file_path !== undefined) {
-          mappedArgs.path = this.normalizePath(mappedArgs.file_path);
+          mappedArgs.path = normalizePath(mappedArgs.file_path, this.logger);
           delete mappedArgs.file_path;
         }
         break;
-        
+
       // Git tools
       case 'git_status':
       case 'git_add':
       case 'git_commit':
         if (mappedArgs.path !== undefined) {
-          mappedArgs.path = this.normalizePath(mappedArgs.path);
+          mappedArgs.path = normalizePath(mappedArgs.path, this.logger);
         }
         break;
     }
-    
+
     this.logger.info(`[ARGS DEBUG] Final mapped args for ${functionName}:`, mappedArgs);
     return mappedArgs;
   }
@@ -268,7 +122,7 @@ export class ToolIntegration {
     // If previous initialization failed, provide clear error message
     if (this.initializationFailed && this.lastInitializationError) {
       this.logger.warn('Previous initialization failed, attempting retry', {
-        previousError: this.lastInitializationError.message
+        previousError: this.lastInitializationError.message,
       });
       // Allow retry by resetting the failure flags
       this.initializationFailed = false;
@@ -299,7 +153,7 @@ export class ToolIntegration {
       const toolRegistry = createLegacyToolRegistry({
         mcpManager: this.mcpManager,
         allowedOrigins: process.env.TOOL_ALLOWED_ORIGINS?.split(',') || ['local'],
-        autoApproveTools: process.env.AUTO_APPROVE_TOOLS === 'true'
+        autoApproveTools: process.env.AUTO_APPROVE_TOOLS === 'true',
       });
 
       // Convert registry to our internal format
@@ -311,20 +165,20 @@ export class ToolIntegration {
           name: tool.function.name,
           description: tool.function.description,
           inputSchema: {
-            properties: tool.function.parameters?.properties || {},
-            required: tool.function.parameters?.required || [],
+            properties: tool.function.parameters.properties || {},
+            required: tool.function.parameters.required || [],
           },
           // Execution will be handled by the unified tool system
           handler: null, // Will be resolved during execution
           // Add the missing execute method that delegates to MCP manager
           execute: async (args: any, context: any) => {
-            const mcpToolName = this.mapToMcpToolName(tool.function.name);
+            const mcpToolName = mapToMcpToolName(tool.function.name);
             const mappedArgs = this.mapArgsForMcpTool(tool.function.name, args);
-            return await this.mcpManager.executeTool(mcpToolName, mappedArgs, context);
+            return this.mcpManager.executeTool(mcpToolName, mappedArgs, context);
           },
         };
         this.availableTools.set(internalTool.id, internalTool);
-        
+
         // DISABLED: Do not register with unified registry to prevent circular dependency
         // MCPServerManager already handles unified registry registration
         // The circular dependency was: ToolIntegration -> unifiedRegistry -> MCPManager -> unifiedRegistry -> loop
@@ -337,20 +191,20 @@ export class ToolIntegration {
           aliases: [], // Could add category prefixes later
           inputSchema: internalTool.inputSchema,
           handler: async (args, context) => {
-            const mcpToolName = this.mapToMcpToolName(internalTool.name);
+              const mcpToolName = mapToMcpToolName(internalTool.name);
             const mappedArgs = this.mapArgsForMcpTool(internalTool.name, args);
             return await this.mcpManager.executeTool(mcpToolName, mappedArgs, context);
           },
           security: {
             requiresApproval: false,
-            riskLevel: this.inferRiskLevel(internalTool.name),
-            allowedOrigins: ['local'],
-          },
-          performance: {
-            estimatedDuration: this.inferDuration(internalTool.name),
-            memoryUsage: 'low',
-            cpuIntensive: false,
-          },
+              riskLevel: inferRiskLevel(internalTool.name),
+              allowedOrigins: ['local'],
+            },
+            performance: {
+              estimatedDuration: inferDuration(internalTool.name),
+              memoryUsage: 'low',
+              cpuIntensive: false,
+            },
         };
         unifiedToolRegistry.registerTool(toolDefinition);
         */
@@ -439,41 +293,49 @@ export class ToolIntegration {
 
     try {
       const functionName = toolCall.function.name;
-      
+
       // Debug the arguments type and value
       this.logger.info(`[DEBUG] Raw arguments:`, {
         type: typeof toolCall.function.arguments,
         value: toolCall.function.arguments,
-        isString: typeof toolCall.function.arguments === 'string'
+        isString: typeof toolCall.function.arguments === 'string',
       });
-      
+
       // Handle both string and object arguments with robust parsing
       let args: any;
       if (typeof toolCall.function.arguments === 'string') {
         try {
           args = JSON.parse(toolCall.function.arguments);
-          
+
           // Check for multiple levels of JSON encoding (common with AI providers)
           let parseAttempts = 0;
           while (typeof args === 'string' && parseAttempts < 3) {
             parseAttempts++;
-            this.logger.debug(`[ARGS DEBUG] Detected level-${parseAttempts} encoded JSON, parsing again`);
-            
+            this.logger.debug(
+              `[ARGS DEBUG] Detected level-${parseAttempts} encoded JSON, parsing again`
+            );
+
             try {
               const parsed = JSON.parse(args);
               args = parsed;
             } catch (innerError) {
-              this.logger.warn(`[ARGS DEBUG] Failed to parse level-${parseAttempts} JSON, using previous level`);
+              this.logger.warn(
+                `[ARGS DEBUG] Failed to parse level-${parseAttempts} JSON, using previous level`
+              );
               break; // Use the previous level if parsing fails
             }
           }
-          
+
           if (parseAttempts > 0) {
-            this.logger.info(`[ARGS DEBUG] Successfully decoded ${parseAttempts}-level JSON encoding`);
+            this.logger.info(
+              `[ARGS DEBUG] Successfully decoded ${parseAttempts}-level JSON encoding`
+            );
           }
         } catch (parseError) {
           this.logger.error(`Failed to parse arguments JSON:`, parseError);
-          throw new Error(`Invalid JSON in tool arguments: ${parseError instanceof Error ? parseError.message : String(parseError)}`);
+          throw new Error(
+            `Invalid JSON in tool arguments: ${parseError instanceof Error ? parseError.message : String(parseError)}`
+          );
         }
       } else {
         // Arguments are already an object
@@ -482,19 +344,23 @@ export class ToolIntegration {
 
       // Validate that args is an object (not a primitive)
       if (args === null || (typeof args !== 'object' && typeof args !== 'undefined')) {
-        this.logger.warn(`[ARGS DEBUG] Arguments resolved to primitive type: ${typeof args}, wrapping in object`);
+        this.logger.warn(
+          `[ARGS DEBUG] Arguments resolved to primitive type: ${typeof args}, wrapping in object`
+        );
         args = { value: args }; // Wrap primitive values
       }
 
       this.logger.info(`Executing tool: ${functionName} with args:`, args);
 
       // Resolve tool name through alias mapping
-      const resolvedToolName = this.resolveToolName(functionName);
+      const resolvedToolName = resolveToolName(functionName, this.availableTools);
       if (!resolvedToolName) {
         const availableTools = Array.from(this.availableTools.keys());
-        const aliasMapping = this.createToolAliasMapping();
-        const availableAliases = Object.keys(aliasMapping).filter(alias => alias !== aliasMapping[alias]);
-        
+        const aliasMapping = createToolAliasMapping(this.availableTools);
+        const availableAliases = Object.keys(aliasMapping).filter(
+          alias => alias !== aliasMapping[alias]
+        );
+
         throw new Error(
           `Unknown tool: ${functionName}. Available tools: ${availableTools.join(', ')}${
             availableAliases.length > 0 ? `. Available aliases: ${availableAliases.join(', ')}` : ''
@@ -518,18 +384,21 @@ export class ToolIntegration {
 
       // Log based on actual execution result status
       if (result.success !== false) {
-        this.logger.info(`Tool ${functionName} (resolved: ${resolvedToolName}) executed successfully`, {
-          success: result.success,
-          executionTime: result.metadata?.executionTime,
-          hasOutput: !!result.output,
-          outputType: typeof result.output
-        });
+        this.logger.info(
+          `Tool ${functionName} (resolved: ${resolvedToolName}) executed successfully`,
+          {
+            success: result.success,
+            executionTime: result.metadata?.executionTime,
+            hasOutput: !!result.output,
+            outputType: typeof result.output,
+          }
+        );
       } else {
         this.logger.warn(`Tool ${functionName} (resolved: ${resolvedToolName}) execution failed`, {
           success: result.success,
           error: result.error || 'Unknown error',
           executionTime: result.metadata?.executionTime,
-          details: result.details
+          details: result.details,
         });
       }
 

--- a/src/infrastructure/tools/tool-mapper.ts
+++ b/src/infrastructure/tools/tool-mapper.ts
@@ -1,0 +1,75 @@
+/**
+ * Mapping utilities between AI-facing tool names and MCP tool identifiers.
+ * Extracted from ToolIntegration for reuse.
+ */
+export function mapToMcpToolName(functionName: string): string {
+  const mapping: Record<string, string> = {
+    // Filesystem tools
+    filesystem_read_file: 'read_file',
+    filesystem_write_file: 'write_file',
+    filesystem_list_directory: 'list_directory',
+    filesystem_get_stats: 'get_stats',
+    // Git tools
+    git_status: 'git_status',
+    git_add: 'git_add',
+    git_commit: 'git_commit',
+    // System tools
+    execute_command: 'execute_command',
+    // Package manager tools
+    npm_install: 'npm_install',
+    npm_run: 'npm_run',
+    // Smithery tools
+    smithery_status: 'smithery_status',
+    smithery_refresh: 'smithery_refresh',
+  };
+
+  return mapping[functionName] || functionName;
+}
+
+export function createToolAliasMapping(availableTools: Map<string, any>): Record<string, string> {
+  const aliases: Record<string, string> = {};
+
+  aliases.filesystem_read_file = 'filesystem_read_file';
+  aliases.read_file = 'filesystem_read_file';
+
+  aliases.filesystem_write_file = 'filesystem_write_file';
+  aliases.write_file = 'filesystem_write_file';
+
+  aliases.filesystem_list_directory = 'filesystem_list_directory';
+  aliases.list_directory = 'filesystem_list_directory';
+
+  aliases.filesystem_get_stats = 'filesystem_get_stats';
+  aliases.get_stats = 'filesystem_get_stats';
+
+  for (const [toolId] of availableTools) {
+    aliases[toolId] = toolId;
+    if (toolId.includes('_')) {
+      const shortName = toolId.split('_').slice(1).join('_');
+      if (shortName) {
+        aliases[shortName] = toolId;
+      }
+    }
+  }
+  return aliases;
+}
+
+export function resolveToolName(
+  functionName: string,
+  availableTools: Map<string, any>
+): string | null {
+  if (availableTools.has(functionName)) {
+    return functionName;
+  }
+  const aliasMapping = createToolAliasMapping(availableTools);
+  const resolvedName = aliasMapping[functionName];
+  if (resolvedName && availableTools.has(resolvedName)) {
+    return resolvedName;
+  }
+  const mcpName = mapToMcpToolName(functionName);
+  for (const [toolId] of availableTools) {
+    if (mapToMcpToolName(toolId) === mcpName) {
+      return toolId;
+    }
+  }
+  return null;
+}

--- a/src/providers/provider-capability-discovery.ts
+++ b/src/providers/provider-capability-discovery.ts
@@ -1,0 +1,40 @@
+import type { ProviderType } from './provider-selection-strategy.js';
+import { ProviderRegistry } from './provider-registry.js';
+
+export interface ProviderCapabilities {
+  supportsStreaming: boolean;
+  supportsToolCalling: boolean;
+}
+
+export interface IProviderCapabilityDiscovery {
+  getCapabilities: (provider: ProviderType, model?: string) => ProviderCapabilities;
+}
+
+export class StaticProviderCapabilityDiscovery implements IProviderCapabilityDiscovery {
+  constructor(private readonly registry: ProviderRegistry) {}
+
+  getCapabilities(provider: ProviderType, model?: string): ProviderCapabilities {
+    const config = this.registry.getProvider(provider);
+    if (!config) {
+      return { supportsStreaming: false, supportsToolCalling: false };
+    }
+    if (provider === 'ollama') {
+      const toolModels = [
+        'llama3',
+        'llama3.1',
+        'llama3.2',
+        'qwen2.5',
+        'qwq',
+        'mistral',
+        'codellama',
+      ];
+      const lower = model?.toLowerCase() || '';
+      const supportsTools = toolModels.some(m => lower.includes(m));
+      return { supportsStreaming: true, supportsToolCalling: supportsTools };
+    }
+    return {
+      supportsStreaming: config.capabilities.streaming,
+      supportsToolCalling: config.capabilities.toolCalling,
+    };
+  }
+}

--- a/src/providers/provider-registry.ts
+++ b/src/providers/provider-registry.ts
@@ -1,0 +1,55 @@
+import type { ProviderType } from './provider-selection-strategy.js';
+
+export interface ProviderConfig {
+  name: ProviderType;
+  endpoint?: string;
+  models?: string[];
+  capabilities: {
+    streaming: boolean;
+    toolCalling: boolean;
+  };
+}
+
+export class ProviderRegistry {
+  constructor(
+    private readonly providers: Record<ProviderType, ProviderConfig>,
+    private fallbackChain: ProviderType[]
+  ) {}
+
+  getProvider(name: ProviderType): ProviderConfig | undefined {
+    return this.providers[name];
+  }
+
+  getFallbackChain(): ProviderType[] {
+    return [...this.fallbackChain];
+  }
+
+  setFallbackChain(chain: ProviderType[]): void {
+    this.fallbackChain = [...chain];
+  }
+}
+
+export const defaultProviderRegistry = new ProviderRegistry(
+  {
+    'lm-studio': {
+      name: 'lm-studio',
+      endpoint: 'ws://localhost:8080',
+      capabilities: { streaming: true, toolCalling: true },
+    },
+    ollama: {
+      name: 'ollama',
+      endpoint: 'http://localhost:11434',
+      capabilities: { streaming: true, toolCalling: true },
+    },
+    huggingface: {
+      name: 'huggingface',
+      endpoint: 'https://api-inference.huggingface.co',
+      capabilities: { streaming: false, toolCalling: false },
+    },
+    auto: {
+      name: 'auto',
+      capabilities: { streaming: true, toolCalling: true },
+    },
+  },
+  ['ollama', 'lm-studio', 'huggingface']
+);

--- a/src/providers/provider-selection-strategy.ts
+++ b/src/providers/provider-selection-strategy.ts
@@ -23,6 +23,11 @@ export interface ProviderSelectionConfig {
   selectionStrategy: 'fastest' | 'most-capable' | 'balanced' | 'adaptive';
   timeoutMs: number;
   maxRetries: number;
+  /**
+   * @deprecated This property is deprecated and will be removed in a future release.
+   * Use the fallback logic in the selection strategy instead.
+   */
+  fallbackChain?: ProviderType[];
 }
 
 export interface SelectionContext {

--- a/src/providers/provider-selection-strategy.ts
+++ b/src/providers/provider-selection-strategy.ts
@@ -13,12 +13,13 @@
 import { EventEmitter } from 'events';
 import { logger } from '../infrastructure/logging/logger.js';
 import { PerformanceMonitor } from '../utils/performance.js';
+import { ProviderRegistry } from './provider-registry.js';
+import type { IProviderCapabilityDiscovery } from './provider-capability-discovery.js';
 
 export type ProviderType = 'ollama' | 'lm-studio' | 'huggingface' | 'auto';
 export type ExecutionMode = 'fast' | 'quality' | 'balanced';
 
 export interface ProviderSelectionConfig {
-  fallbackChain: ProviderType[];
   selectionStrategy: 'fastest' | 'most-capable' | 'balanced' | 'adaptive';
   timeoutMs: number;
   maxRetries: number;
@@ -44,19 +45,28 @@ export interface SelectionResult {
 }
 
 export interface IProviderSelectionStrategy {
-  selectProvider(context: SelectionContext): SelectionResult;
-  createFallbackChain(primaryProvider: ProviderType, context: SelectionContext): ProviderType[];
-  validateProviderForContext(provider: ProviderType, context: SelectionContext): boolean;
+  selectProvider: (context: SelectionContext) => SelectionResult;
+  createFallbackChain: (primaryProvider: ProviderType, context: SelectionContext) => ProviderType[];
+  validateProviderForContext: (provider: ProviderType, context: SelectionContext) => boolean;
 }
 
 export class ProviderSelectionStrategy extends EventEmitter implements IProviderSelectionStrategy {
-  private config: ProviderSelectionConfig;
-  private performanceMonitor: PerformanceMonitor;
+  private readonly config: ProviderSelectionConfig;
+  private readonly performanceMonitor: PerformanceMonitor;
+  private readonly registry: ProviderRegistry;
+  private readonly capabilityDiscovery: IProviderCapabilityDiscovery;
 
-  constructor(config: ProviderSelectionConfig, performanceMonitor: PerformanceMonitor) {
+  constructor(
+    config: ProviderSelectionConfig,
+    performanceMonitor: PerformanceMonitor,
+    registry: ProviderRegistry,
+    capabilityDiscovery: IProviderCapabilityDiscovery
+  ) {
     super();
     this.config = config;
     this.performanceMonitor = performanceMonitor;
+    this.registry = registry;
+    this.capabilityDiscovery = capabilityDiscovery;
   }
 
   /**
@@ -110,7 +120,7 @@ export class ProviderSelectionStrategy extends EventEmitter implements IProvider
           break;
 
         default:
-          selectedProvider = this.config.fallbackChain[0];
+          selectedProvider = this.registry.getFallbackChain()[0];
           reason = 'Default fallback provider';
           confidence = 0.6;
       }
@@ -135,10 +145,11 @@ export class ProviderSelectionStrategy extends EventEmitter implements IProvider
    * Create fallback chain prioritizing the selected provider
    */
   createFallbackChain(primaryProvider: ProviderType, context: SelectionContext): ProviderType[] {
+    const baseChain = this.registry.getFallbackChain();
     const fallbackChain =
       primaryProvider === 'auto'
-        ? [...this.config.fallbackChain]
-        : [primaryProvider, ...this.config.fallbackChain.filter(p => p !== primaryProvider)];
+        ? [...baseChain]
+        : [primaryProvider, ...baseChain.filter(p => p !== primaryProvider)];
 
     // Filter out providers that don't support the required context
     return fallbackChain.filter(provider => this.validateProviderForContext(provider, context));
@@ -149,8 +160,11 @@ export class ProviderSelectionStrategy extends EventEmitter implements IProvider
    */
   validateProviderForContext(provider: ProviderType, context: SelectionContext): boolean {
     // Check tool support requirement
-    if (context.requiresTools && !this.modelSupportsTools(provider, context.model)) {
-      return false;
+    if (context.requiresTools) {
+      const caps = this.capabilityDiscovery.getCapabilities(provider, context.model);
+      if (!caps.supportsToolCalling) {
+        return false;
+      }
     }
 
     // Add other validation logic as needed
@@ -166,7 +180,7 @@ export class ProviderSelectionStrategy extends EventEmitter implements IProvider
       ([, a], [, b]) => a.averageLatency - b.averageLatency
     );
 
-    return (sortedBySpeed[0]?.[0] as ProviderType) || this.config.fallbackChain[0];
+    return (sortedBySpeed[0]?.[0] as ProviderType) || this.registry.getFallbackChain()[0];
   }
 
   /**
@@ -178,7 +192,7 @@ export class ProviderSelectionStrategy extends EventEmitter implements IProvider
       ([, a], [, b]) => b.successRate - a.successRate
     );
 
-    return (sortedByQuality[0]?.[0] as ProviderType) || this.config.fallbackChain[0];
+    return (sortedByQuality[0]?.[0] as ProviderType) || this.registry.getFallbackChain()[0];
   }
 
   /**
@@ -192,7 +206,7 @@ export class ProviderSelectionStrategy extends EventEmitter implements IProvider
     }));
 
     scored.sort((a, b) => b.score - a.score);
-    return (scored[0]?.provider as ProviderType) || this.config.fallbackChain[0];
+    return (scored[0]?.provider as ProviderType) || this.registry.getFallbackChain()[0];
   }
 
   /**
@@ -233,9 +247,9 @@ export class ProviderSelectionStrategy extends EventEmitter implements IProvider
    * Find provider capable of handling tools
    */
   private selectToolCapableProvider(model?: string): ProviderType | null {
-    // Check each provider for tool support
-    for (const provider of this.config.fallbackChain) {
-      if (this.modelSupportsTools(provider, model)) {
+    for (const provider of this.registry.getFallbackChain()) {
+      const caps = this.capabilityDiscovery.getCapabilities(provider, model);
+      if (caps.supportsToolCalling) {
         return provider;
       }
     }
@@ -243,51 +257,12 @@ export class ProviderSelectionStrategy extends EventEmitter implements IProvider
   }
 
   /**
-   * Check if provider/model combination supports tools
-   */
-  private modelSupportsTools(provider: ProviderType, model?: string): boolean {
-    if (provider === 'lm-studio') {
-      return true; // LM Studio generally supports OpenAI-compatible function calling
-    }
-
-    if (provider === 'ollama') {
-      // If no specific model provided, assume auto-selection will pick a supported model
-      if (!model) {
-        logger.debug(
-          'No specific model provided, assuming auto-selection will pick supported model'
-        );
-        return true; // Trust that auto-selection picks qwen2.5-coder which supports tools
-      }
-
-      // Only certain Ollama models support function calling
-      const model_name = model.toLowerCase();
-      const supportedModels = [
-        'llama3',
-        'llama3.1',
-        'llama3.2',
-        'qwen2.5',
-        'qwq',
-        'mistral',
-        'codellama',
-      ];
-
-      const isSupported = supportedModels.some(supportedModel =>
-        model_name.includes(supportedModel)
-      );
-      logger.debug('Model tool support check', { model: model_name, isSupported });
-      return isSupported;
-    }
-
-    return false; // Conservative default - no tools for unknown providers
-  }
-
-  /**
    * Get current selection metrics
    */
-  getSelectionMetrics(): any {
+  getSelectionMetrics(): unknown {
     return {
       strategy: this.config.selectionStrategy,
-      fallbackChain: this.config.fallbackChain,
+      fallbackChain: this.registry.getFallbackChain(),
       providerMetrics: this.performanceMonitor.getProviderMetrics(),
     };
   }
@@ -306,7 +281,7 @@ export class ProviderSelectionStrategy extends EventEmitter implements IProvider
    */
   updateFallbackChain(fallbackChain: ProviderType[]): void {
     logger.info(`Updating fallback chain to: ${fallbackChain.join(' -> ')}`);
-    this.config.fallbackChain = fallbackChain;
+    this.registry.setFallbackChain(fallbackChain);
     this.emit('fallbackChainUpdated', { fallbackChain });
   }
 }

--- a/src/providers/provider-selection-strategy.ts
+++ b/src/providers/provider-selection-strategy.ts
@@ -50,9 +50,9 @@ export interface SelectionResult {
 }
 
 export interface IProviderSelectionStrategy {
-  selectProvider: (context: SelectionContext) => SelectionResult;
-  createFallbackChain: (primaryProvider: ProviderType, context: SelectionContext) => ProviderType[];
-  validateProviderForContext: (provider: ProviderType, context: SelectionContext) => boolean;
+  selectProvider(context: SelectionContext): SelectionResult;
+  createFallbackChain(primaryProvider: ProviderType, context: SelectionContext): ProviderType[];
+  validateProviderForContext(provider: ProviderType, context: SelectionContext): boolean;
 }
 
 export class ProviderSelectionStrategy extends EventEmitter implements IProviderSelectionStrategy {


### PR DESCRIPTION
## Summary
- centralize provider settings and expose capabilities
- modularize tool integration into reusable helpers
- lazy-load Rust execution backend for flexible runtime

## Testing
- `npx eslint src/infrastructure/tools/path-normalizer.ts src/infrastructure/tools/risk-scorer.ts src/infrastructure/tools/tool-mapper.ts src/providers/provider-capability-discovery.ts src/providers/provider-registry.ts src/providers/provider-selection-strategy.ts src/application/services/client.ts src/application/services/service-factory.ts src/infrastructure/tools/tool-integration.ts --fix` *(errors: Parameter should be a read only type, no-unnecessary-condition, etc.)*
- `npx tsc --noEmit`
- `npm test` *(fails: Cannot find module '../../../../src/core/agents/agent-communication-protocol.js', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9d6477c4832d96ed0b4a28167033