### PR TITLE
refactor: add typed orchestrator dependencies

### DIFF
--- a/src/application/services/concrete-workflow-orchestrator.ts
+++ b/src/application/services/concrete-workflow-orchestrator.ts
@@ -23,6 +23,7 @@ import {
   ModelTool,
   ModelResponse,
 } from '../../domain/interfaces/model-client.js';
+import { IMcpManager } from '../../domain/interfaces/mcp-manager.js';
 import { logger } from '../../infrastructure/logging/logger.js';
 import { getErrorMessage } from '../../utils/error-utils.js';
 import { randomUUID } from 'crypto';
@@ -49,7 +50,7 @@ export class ConcreteWorkflowOrchestrator extends EventEmitter implements IWorkf
   private userInteraction!: IUserInteraction;
   private eventBus!: IEventBus;
   private modelClient?: IModelClient;
-  private mcpManager?: any;
+  private mcpManager?: IMcpManager;
   private requestExecutionManager?: RequestExecutionManager;
   private isInitialized = false;
   private toolRegistry?: ToolRegistry;
@@ -84,7 +85,10 @@ export class ConcreteWorkflowOrchestrator extends EventEmitter implements IWorkf
   /**
    * Helper method to route model requests through RequestExecutionManager when available
    */
-  public async processModelRequest(request: ModelRequest, context?: any): Promise<ModelResponse> {
+  public async processModelRequest(
+    request: ModelRequest,
+    context?: WorkflowContext
+  ): Promise<ModelResponse> {
     if (this.requestExecutionManager && this.modelClient) {
       // Use RequestExecutionManager for advanced execution strategies
       logger.debug('Routing model request through RequestExecutionManager');

--- a/src/application/services/orchestrator/tool-execution-router.ts
+++ b/src/application/services/orchestrator/tool-execution-router.ts
@@ -1,6 +1,6 @@
 import { WorkflowRequest } from '../../../domain/interfaces/workflow-orchestrator.js';
 import { ModelRequest, ModelResponse } from '../../../domain/interfaces/model-client.js';
-import { MCPServerManager } from '../../../mcp-servers/mcp-server-manager.js';
+import { IMcpManager } from '../../../domain/interfaces/mcp-manager.js';
 import { logger } from '../../../infrastructure/logging/logger.js';
 import { getErrorMessage } from '../../../utils/error-utils.js';
 import { getGlobalEnhancedToolIntegration } from '../../../infrastructure/tools/enhanced-tool-integration.js';
@@ -9,7 +9,7 @@ import { getGlobalEnhancedToolIntegration } from '../../../infrastructure/tools/
  * Routes tool execution requests and handles follow-up model synthesis.
  */
 export class ToolExecutionRouter {
-  constructor(private mcpManager: MCPServerManager) {}
+  constructor(private mcpManager: IMcpManager) {}
 
   async handleToolCalls(
     response: ModelResponse,

--- a/src/application/services/orchestrator/tool-registry.ts
+++ b/src/application/services/orchestrator/tool-registry.ts
@@ -1,90 +1,7 @@
 import { ModelTool } from '../../../domain/interfaces/model-client.js';
+import { IMcpManager } from '../../../domain/interfaces/mcp-manager.js';
 import { createDefaultToolRegistry } from '../../../infrastructure/tools/default-tool-registry.js';
 import { logger } from '../../../infrastructure/logging/logger.js';
-import { 
-  ToolExecutionArgs, 
-  ToolExecutionContext, 
-  ToolExecutionResult,
-  ToolExecutionOptions 
-} from '../../../infrastructure/types/tool-execution-types.js';
-
-/**
- * Complete MCP Manager Interface
- * 
- * Defines the contract for Model Context Protocol server management
- * Provides type safety for tool execution, server lifecycle, and monitoring
- */
-export interface McpManager {
-  // Core Lifecycle Methods
-  initialize(): Promise<void>;
-  startServers(): Promise<void>;
-  startServer(serverName: string): Promise<void>;
-  shutdown(): Promise<void>;
-
-  // Tool Execution (Primary Interface)
-  executeTool(
-    toolName: string, 
-    args: ToolExecutionArgs, 
-    context?: ToolExecutionContext,
-    options?: ToolExecutionOptions
-  ): Promise<ToolExecutionResult>;
-
-  // Convenient File System Methods
-  readFileSecure(filePath: string): Promise<string>;
-  writeFileSecure(filePath: string, content: string): Promise<void>;
-  listDirectorySecure(directoryPath: string): Promise<string[]>;
-  getFileStats(filePath: string): Promise<{
-    exists: boolean;
-    size?: number;
-    modified?: Date;
-  }>;
-
-  // Command Execution
-  executeCommandSecure(command: string, args?: string[]): Promise<string>;
-
-  // Server Management
-  listServers(): Promise<string[]>;
-  getServerStatus(serverId: string): any;
-  
-  // Health and Monitoring
-  getHealthStatus(): Promise<{
-    overall: 'healthy' | 'degraded' | 'critical';
-    servers: Array<{
-      serverId: string;
-      status: 'running' | 'error' | 'stopped';
-      uptime: number;
-      successRate: number;
-      lastSeen: Date;
-    }>;
-    capabilities: {
-      totalTools: number;
-      totalServers: number;
-      registryStatus: string;
-      smitheryEnabled?: boolean;
-      smitheryTools?: number;
-      smitheryServers?: number;
-    };
-  }>;
-
-  healthCheck(): Promise<{
-    status: string;
-    servers: Array<{
-      serverId: string;
-      status: string;
-      uptime: number;
-      lastChecked: Date;
-    }>;
-  }>;
-
-  getMonitoringSummary(): {
-    totalRequests: number;
-    successCount: number;
-    errorCount: number;
-    averageLatency: number;
-    uptimePercentage: number;
-    lastActivity?: Date;
-  };
-}
 
 /**
  * Wrapper around MCP tool registry with simple caching.
@@ -92,7 +9,7 @@ export interface McpManager {
 export class ToolRegistry {
   private registryCache: Map<string, ModelTool> | null = null;
 
-  constructor(private readonly mcpManager?: McpManager) {}
+  constructor(private readonly mcpManager?: IMcpManager) {}
 
   private initializeRegistry(): Map<string, ModelTool> {
     if (!this.registryCache) {

--- a/src/domain/interfaces/index.ts
+++ b/src/domain/interfaces/index.ts
@@ -11,6 +11,7 @@ export * from './workflow-orchestrator.js';
 export * from './event-bus.js';
 export * from './user-interaction.js';
 export * from './model-client.js';
+export * from './mcp-manager.js';
 export * from './tool-system.js';
 export * from './configuration.js';
 export * from './provider-capability-registry.js';

--- a/src/domain/interfaces/mcp-manager.ts
+++ b/src/domain/interfaces/mcp-manager.ts
@@ -84,4 +84,3 @@ export interface IMcpManager {
   };
 }
 
-export type McpManager = IMcpManager;

--- a/src/domain/interfaces/mcp-manager.ts
+++ b/src/domain/interfaces/mcp-manager.ts
@@ -1,0 +1,87 @@
+/**
+ * MCP Manager Interface
+ *
+ * Defines the contract for Model Context Protocol server management
+ * providing type safety for tool execution, server lifecycle, and monitoring.
+ */
+
+import {
+  ToolExecutionArgs,
+  ToolExecutionContext,
+  ToolExecutionOptions,
+  ToolExecutionResult,
+} from '../../infrastructure/types/tool-execution-types.js';
+
+export interface IMcpManager {
+  // Core Lifecycle Methods
+  initialize(): Promise<void>;
+  startServers(): Promise<void>;
+  startServer(serverName: string): Promise<void>;
+  shutdown(): Promise<void>;
+
+  // Tool Execution (Primary Interface)
+  executeTool(
+    toolName: string,
+    args: ToolExecutionArgs,
+    context?: ToolExecutionContext,
+    options?: ToolExecutionOptions
+  ): Promise<ToolExecutionResult>;
+
+  // Convenient File System Methods
+  readFileSecure(filePath: string): Promise<string>;
+  writeFileSecure(filePath: string, content: string): Promise<void>;
+  listDirectorySecure(directoryPath: string): Promise<string[]>;
+  getFileStats(filePath: string): Promise<{
+    exists: boolean;
+    size?: number;
+    modified?: Date;
+  }>;
+
+  // Command Execution
+  executeCommandSecure(command: string, args?: string[]): Promise<string>;
+
+  // Server Management
+  listServers(): Promise<string[]>;
+  getServerStatus(serverId: string): any;
+
+  // Health and Monitoring
+  getHealthStatus(): Promise<{
+    overall: 'healthy' | 'degraded' | 'critical';
+    servers: Array<{
+      serverId: string;
+      status: 'running' | 'error' | 'stopped';
+      uptime: number;
+      successRate: number;
+      lastSeen: Date;
+    }>;
+    capabilities: {
+      totalTools: number;
+      totalServers: number;
+      registryStatus: string;
+      smitheryEnabled?: boolean;
+      smitheryTools?: number;
+      smitheryServers?: number;
+    };
+  }>;
+
+  healthCheck(): Promise<{
+    status: string;
+    servers: Array<{
+      serverId: string;
+      status: string;
+      uptime: number;
+      lastChecked: Date;
+    }>;
+  }>;
+
+  getMonitoringSummary(): {
+    totalRequests: number;
+    successCount: number;
+    errorCount: number;
+    averageLatency: number;
+    uptimePercentage: number;
+    lastActivity?: Date;
+  };
+}
+
+export type McpManager = IMcpManager;

--- a/src/domain/interfaces/workflow-orchestrator.ts
+++ b/src/domain/interfaces/workflow-orchestrator.ts
@@ -7,6 +7,10 @@
 
 import { IUserInteraction } from './user-interaction.js';
 import { IEventBus } from './event-bus.js';
+import { IModelClient, ModelRequest, ModelResponse } from './model-client.js';
+import { IMcpManager } from './mcp-manager.js';
+import { IUnifiedSecurityValidator } from '../services/unified-security-validator.js';
+import { IUnifiedConfigurationManager } from '../services/unified-configuration-manager.js';
 import {
   ToolExecutionArgs,
   ToolExecutionResult,
@@ -17,7 +21,7 @@ export interface PromptPayload {
   prompt: string;
   voiceId?: string;
   model?: string;
-  parameters?: Record<string, any>;
+  parameters?: Record<string, unknown>;
 }
 
 export interface ToolExecutionPayload {
@@ -32,23 +36,23 @@ export interface ModelRequestPayload {
     role: 'user' | 'assistant' | 'system';
     content: string;
   }>;
-  parameters?: Record<string, any>;
+  parameters?: Record<string, unknown>;
 }
 
 export interface AnalysisPayload {
   target: string;
   type: 'file' | 'directory' | 'codebase';
-  options?: Record<string, any>;
+  options?: Record<string, unknown>;
 }
 
-export type WorkflowPayload = Record<string, any>;
+export type WorkflowPayload = Record<string, unknown>;
 
 // Result types for different workflow operations
 export interface SpiralProcessResult {
   phases: Array<{
     name: string;
     output: string;
-    metadata: Record<string, any>;
+    metadata: Record<string, unknown>;
   }>;
   finalOutput: string;
   convergenceReached: boolean;
@@ -72,15 +76,15 @@ export interface WorkflowRequest {
   type: 'prompt' | 'tool-execution' | 'model-request' | 'analysis';
   payload: WorkflowPayload;
   context?: WorkflowContext;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface WorkflowResponse {
   id: string;
   success: boolean;
-  result?: any;
+  result?: unknown;
   error?: Error;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface WorkflowContext {
@@ -105,7 +109,7 @@ export interface IWorkflowOrchestrator {
   /**
    * Process a model request with routing and fallbacks
    */
-  processModelRequest(request: any, context?: any): Promise<any>;
+  processModelRequest(request: ModelRequest, context?: WorkflowContext): Promise<ModelResponse>;
 
   /**
    * Initialize the orchestrator with dependencies
@@ -125,22 +129,22 @@ export interface LivingSpiralCoordinatorInterface {
   /**
    * Execute the complete Living Spiral process
    */
-  executeSpiralProcess(initialPrompt: string): Promise<any>;
+  executeSpiralProcess(initialPrompt: string): Promise<unknown>;
 
   /**
    * Execute a single spiral iteration
    */
-  executeSpiralIteration(input: string, iteration: number): Promise<any>;
+  executeSpiralIteration(input: string, iteration: number): Promise<unknown>;
 
   /**
    * Check if convergence has been achieved
    */
-  checkConvergence(results: any[]): Promise<boolean>;
+  checkConvergence(results: unknown[]): Promise<boolean>;
 
   /**
    * Analyze code or files
    */
-  analyzeCode(filePath: string, context: WorkflowContext): Promise<any>;
+  analyzeCode(filePath: string, context: WorkflowContext): Promise<unknown>;
 
   /**
    * Initialize the orchestrator with dependencies
@@ -157,10 +161,10 @@ export interface LivingSpiralCoordinatorInterface {
 export interface OrchestratorDependencies {
   userInteraction: IUserInteraction;
   eventBus: IEventBus;
-  modelClient?: any;
-  mcpManager?: any;
-  securityValidator?: any;
-  configManager?: any;
+  modelClient?: IModelClient;
+  mcpManager?: IMcpManager;
+  securityValidator?: IUnifiedSecurityValidator;
+  configManager?: IUnifiedConfigurationManager;
   /**
    * Optional aggregated runtime context replacing scattered singletons.
    * When supplied, fields inside take precedence for orchestration internals.
@@ -173,7 +177,7 @@ export interface OrchestratorDependencies {
  */
 export interface WorkflowEvents {
   'workflow:started': { id: string; type: string };
-  'workflow:completed': { id: string; result: any };
+  'workflow:completed': { id: string; result: unknown };
   'workflow:failed': { id: string; error: Error };
   'workflow:progress': { id: string; message: string; progress?: number };
 }

--- a/src/infrastructure/tools/default-tool-registry.ts
+++ b/src/infrastructure/tools/default-tool-registry.ts
@@ -6,12 +6,12 @@ import {
   TypedToolIdentifiers,
   TYPED_TOOL_CATALOG 
 } from './typed-tool-identifiers.js';
-import { McpManager } from '../../application/services/orchestrator/tool-registry.js';
+import { IMcpManager } from '../../domain/interfaces/mcp-manager.js';
 
 const logger = createLogger('DefaultToolRegistry');
 
 interface ToolRegistryOptions {
-  mcpManager?: McpManager;
+  mcpManager?: IMcpManager;
   allowedOrigins?: string[];
   autoApproveTools?: boolean;
 }

--- a/tests/unit/core/workflow-orchestrator-types.test.ts
+++ b/tests/unit/core/workflow-orchestrator-types.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Compile-time type tests for workflow orchestrator dependencies.
+ * Ensures OrchestratorDependencies uses domain interfaces.
+ */
+
+import type {
+  OrchestratorDependencies,
+  WorkflowContext,
+} from '../../../src/domain/interfaces/workflow-orchestrator.js';
+import type { IModelClient } from '../../../src/domain/interfaces/model-client.js';
+import type { IMcpManager } from '../../../src/domain/interfaces/mcp-manager.js';
+import type { IUnifiedSecurityValidator } from '../../../src/domain/services/unified-security-validator.js';
+import type { IUnifiedConfigurationManager } from '../../../src/domain/services/unified-configuration-manager.js';
+import type { IUserInteraction } from '../../../src/domain/interfaces/user-interaction.js';
+import type { IEventBus } from '../../../src/domain/interfaces/event-bus.js';
+
+describe('OrchestratorDependencies types', () => {
+  it('should accept valid dependency implementations', () => {
+    const deps: OrchestratorDependencies = {
+      userInteraction: {} as IUserInteraction,
+      eventBus: {} as IEventBus,
+      modelClient: {} as IModelClient,
+      mcpManager: {} as IMcpManager,
+      securityValidator: {} as IUnifiedSecurityValidator,
+      configManager: {} as IUnifiedConfigurationManager,
+    };
+
+    expect(deps).toBeDefined();
+  });
+
+  it('should support optional context', () => {
+    const ctx: WorkflowContext = {
+      sessionId: 'abc',
+      workingDirectory: '.',
+      permissions: [],
+      securityLevel: 'low',
+    };
+    expect(ctx.sessionId).toBe('abc');
+  });
+});


### PR DESCRIPTION
## Summary
- add IMcpManager and type orchestrator dependencies
- wire tool registry and execution router to typed MCP manager
- add compile-time tests for orchestrator dependency contracts

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: installation warnings)*
- `npm run typecheck` *(fails: no output)*
- `npm test` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf0e16d6c832d841a6456f714bfc8