### PR TITLE
fix(provider): correct adapter type export and lint dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -118,6 +118,7 @@
         "crucible": "dist/bin/crucible.js"
       },
       "devDependencies": {
+        "@eslint/js": "^9.35.0",
         "@napi-rs/cli": "^3.1.5",
         "@types/archiver": "^6.0.3",
         "@types/better-sqlite3": "^7.6.8",
@@ -3658,13 +3659,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "version": "9.35.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
+      "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@gar/promisify": {
@@ -15129,6 +15133,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/eslint/node_modules/ajv": {

--- a/package.json
+++ b/package.json
@@ -202,6 +202,7 @@
     "zod": "^3.22.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.35.0",
     "@napi-rs/cli": "^3.1.5",
     "@types/archiver": "^6.0.3",
     "@types/better-sqlite3": "^7.6.8",
@@ -239,11 +240,7 @@
     "directories": {
       "output": "build/desktop"
     },
-    "files": [
-      "dist/**/*",
-      "config/**/*",
-      "node_modules/**/*"
-    ],
+    "files": ["dist/**/*", "config/**/*", "node_modules/**/*"],
     "mac": {
       "category": "public.app-category.developer-tools"
     },

--- a/src/application/services/provider-adapters/index.ts
+++ b/src/application/services/provider-adapters/index.ts
@@ -1,4 +1,4 @@
-export { ProviderAdapter } from './provider-adapter.js';
+export type { ProviderAdapter } from './provider-adapter.js';
 export { OllamaAdapter } from './ollama-adapter.js';
 export { LMStudioAdapter } from './lm-studio-adapter.js';
 export { ClaudeAdapter } from './claude-adapter.js';


### PR DESCRIPTION
## Summary
- export `ProviderAdapter` as a type from provider-adapter barrel to avoid runtime export errors
- add missing `@eslint/js` dev dependency so lint can run

## Testing
- `npm run lint:fix`
- `npm run format`
- `npm run typecheck` *(fails: Argument of type 'unknown' is not assignable to parameter of type 'string | undefined')*
- `npm test` *(fails: Cannot find module '../../../../src/core/agents/agent-communication-protocol.js' from 'tests/unit/core/agents/agent-communication-protocol.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68bbf47e7aa8832da9ad21d9345bae6e