### PR TITLE
fix: align orchestrator context types and MCP status

### DIFF
--- a/src/domain/interfaces/mcp-manager.ts
+++ b/src/domain/interfaces/mcp-manager.ts
@@ -12,6 +12,15 @@ import {
   ToolExecutionResult,
 } from '../../infrastructure/types/tool-execution-types.js';
 
+export interface McpServerStatus {
+  id: string;
+  status: 'stopped' | 'starting' | 'running' | 'error' | 'reconnecting';
+  health: 'healthy' | 'degraded' | 'unhealthy' | 'circuit_open';
+  capabilities: string[];
+  uptime?: number;
+  lastSeen: Date;
+}
+
 export interface IMcpManager {
   // Core Lifecycle Methods
   initialize(): Promise<void>;
@@ -42,7 +51,7 @@ export interface IMcpManager {
 
   // Server Management
   listServers(): Promise<string[]>;
-  getServerStatus(serverId: string): any;
+  getServerStatus(serverId: string): McpServerStatus;
 
   // Health and Monitoring
   getHealthStatus(): Promise<{
@@ -83,4 +92,3 @@ export interface IMcpManager {
     lastActivity?: Date;
   };
 }
-

--- a/src/domain/interfaces/workflow-orchestrator.ts
+++ b/src/domain/interfaces/workflow-orchestrator.ts
@@ -9,6 +9,7 @@ import { IUserInteraction } from './user-interaction.js';
 import { IEventBus } from './event-bus.js';
 import { IModelClient, ModelRequest, ModelResponse } from './model-client.js';
 import { IMcpManager } from './mcp-manager.js';
+import { ProjectContext } from '../types/unified-types.js';
 import { IUnifiedSecurityValidator } from '../services/unified-security-validator.js';
 import { IUnifiedConfigurationManager } from '../services/unified-configuration-manager.js';
 import {
@@ -104,12 +105,16 @@ export interface IWorkflowOrchestrator {
   /**
    * Execute a tool with proper context and security
    */
-  executeTool(toolName: string, args: ToolExecutionArgs, context: WorkflowContext): Promise<ToolExecutionResult>;
+  executeTool(
+    toolName: string,
+    args: ToolExecutionArgs,
+    context: WorkflowContext
+  ): Promise<ToolExecutionResult>;
 
   /**
    * Process a model request with routing and fallbacks
    */
-  processModelRequest(request: ModelRequest, context?: WorkflowContext): Promise<ModelResponse>;
+  processModelRequest(request: ModelRequest, context?: ProjectContext): Promise<ModelResponse>;
 
   /**
    * Initialize the orchestrator with dependencies
@@ -156,7 +161,6 @@ export interface LivingSpiralCoordinatorInterface {
    */
   shutdown(): Promise<void>;
 }
-
 
 export interface OrchestratorDependencies {
   userInteraction: IUserInteraction;


### PR DESCRIPTION
## Summary
- type MCP manager server status and remove `any`
- pass project-aware context to request execution manager
- expose ProjectContext in workflow orchestrator interface

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run format`
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest')*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68bbf456a338832d916f1019f8937c34