### PR TITLE
test(search): address review feedback in fixtures

### DIFF
--- a/tests/search/command-line-search-engine.test.ts
+++ b/tests/search/command-line-search-engine.test.ts
@@ -4,13 +4,13 @@
  * Validates cross-platform compatibility and performance claims
  */
 
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from '@jest/globals';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 import { CommandLineSearchEngine } from '../../src/core/search/command-line-search-engine.js';
 import { CodePatternGenerator } from '../../src/core/search/code-pattern-generator.js';
 import type { SearchOptions, SearchResult } from '../../src/core/search/types.js';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { mkdtemp, rm, writeFile, mkdir } from 'fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
 import * as os from 'os';
 
 describe('Command Line Search Engine - Cross-Platform Tests', () => {
@@ -36,11 +36,12 @@ describe('Command Line Search Engine - Cross-Platform Tests', () => {
       
       export class DataProcessor {
         private data: UserData[] = [];
-        
+
         async processUsers(users: UserData[]): Promise<void> {
           this.data = users;
         }
-        
+
+        // edge case: return undefined when user is missing
         getUserById(id: number): UserData | undefined {
           return this.data.find(user => user.id === id);
         }
@@ -67,6 +68,7 @@ describe('Command Line Search Engine - Cross-Platform Tests', () => {
         }
 
         applyDiscount(rate) {
+          // apply discount for clearance
           return this.getTotal() * (1 - rate);
         }
       }
@@ -417,7 +419,7 @@ describe('Command Line Search Engine - Cross-Platform Tests', () => {
       const results = await searchEngine.searchInFiles(options);
 
       expect(results.length).toBeGreaterThan(0);
-      const match = results[0];
+      const [match] = results;
 
       expect(match.content).toBeDefined();
       expect(match.content.length).toBeGreaterThan(0);
@@ -446,7 +448,7 @@ describe('Command Line Search Engine - Cross-Platform Tests', () => {
       const results = await searchEngine.searchInFiles(options);
 
       expect(results.length).toBeGreaterThan(0);
-      const match = results[0];
+      const [match] = results;
 
       expect(match.line).toBeGreaterThan(0);
       expect(match.column).toBeGreaterThanOrEqual(0);

--- a/tests/search/search-integration.test.ts
+++ b/tests/search/search-integration.test.ts
@@ -4,7 +4,7 @@
  * Provides comprehensive test coverage report for hybrid search system
  */
 
-import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 import { HybridSearchCoordinator } from '../../src/core/search/hybrid-search-coordinator.js';
 import { CommandLineSearchEngine } from '../../src/core/search/command-line-search-engine.js';
 import { AdvancedSearchCacheManager } from '../../src/core/search/advanced-search-cache.js';
@@ -18,7 +18,7 @@ import type { RAGQuery, SearchResult } from '../../src/core/search/types.js';
 import type { CLIContext } from '../../src/core/cli/cli-types.js';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { mkdtemp, rm, writeFile, mkdir } from 'fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
 import * as os from 'os';
 
 describe('Search Integration Test Suite - Master Test Runner', () => {
@@ -93,8 +93,9 @@ describe('Search Integration Test Suite - Master Test Runner', () => {
         }
 
         async findUserById(id: string): Promise<User | null> {
-          if (this.cache.has(id)) {
-            return this.cache.get(id) ?? null;
+          const cachedUser = this.cache.get(id);
+          if (cachedUser !== undefined) {
+            return cachedUser;
           }
           const user = await this.repository.findById(id);
           if (user) {
@@ -258,8 +259,8 @@ describe('Search Integration Test Suite - Master Test Runner', () => {
 
   afterAll(async () => {
     // Cleanup all components
-    await hybridCoordinator?.shutdown();
-    await cacheManager?.shutdown();
+    await hybridCoordinator.shutdown();
+    await cacheManager.shutdown();
     await cliIntegration?.shutdown();
 
     // Remove test workspace
@@ -623,7 +624,7 @@ describe('Search Integration Test Suite - Master Test Runner', () => {
   });
 
   describe('Integration Test Summary', () => {
-    it('should report comprehensive test coverage', async () => {
+    it('should report comprehensive test coverage', () => {
       console.log('\n📊 Search Integration Test Summary:');
 
       // Component initialization status


### PR DESCRIPTION
## Summary
- add edge-case and discount tokens to search-engine fixtures
- refactor test cache retrieval to avoid non-null assertions
- streamline integration summary test

## Testing
- `npm run lint:fix -- tests/search/command-line-search-engine.test.ts tests/search/performance-benchmarks.test.ts tests/search/search-integration.test.ts`
- `npm run format`
- `npm run typecheck`
- `npm test` *(fails: Cannot find module '../../../../src/core/agents/agent-communication-protocol.js' from 'tests/unit/core/agents/agent-communication-protocol.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68bbf4e20f70832d9f4eb5ec1519b087