### PR TITLE
refactor(cli): modularize coordinator with DI

### DIFF
--- a/src/application/services/cli/cli-orchestrator.ts
+++ b/src/application/services/cli/cli-orchestrator.ts
@@ -1,0 +1,169 @@
+import { performance } from 'perf_hooks';
+import { randomUUID } from 'crypto';
+import { EnterpriseSecurityFramework } from '../../../infrastructure/security/enterprise-security-framework.js';
+import { ResilientCLIWrapper } from '../../../infrastructure/resilience/resilient-cli-wrapper.js';
+import { MetricsCollector } from '../cli/metrics-collector.js';
+import { UseCaseRouter } from '../cli/use-case-router.js';
+import { SessionManager } from '../cli/session-manager.js';
+import { logger } from '../../../infrastructure/logging/unified-logger.js';
+import type {
+  CLIOperationRequest,
+  CLIOperationResponse,
+  UnifiedCLIOptions,
+} from '../unified-cli-coordinator.js';
+
+interface Dependencies {
+  securityFramework: EnterpriseSecurityFramework;
+  metricsCollector: MetricsCollector;
+  resilientWrapper: ResilientCLIWrapper;
+  useCaseRouter: UseCaseRouter;
+  sessionManager: SessionManager;
+  calculateSystemHealth: () => number;
+}
+
+export interface ICLIOrchestrator {
+  processOperation(
+    request: Readonly<CLIOperationRequest>,
+    options: UnifiedCLIOptions
+  ): Promise<CLIOperationResponse>;
+}
+
+export class CLIOrchestrator implements ICLIOrchestrator {
+  public constructor(private readonly deps: Dependencies) {}
+
+  public async processOperation(
+    request: Readonly<CLIOperationRequest>,
+    options: UnifiedCLIOptions
+  ): Promise<CLIOperationResponse> {
+    const startTime = performance.now();
+    const operationId = request.id || randomUUID();
+    const {
+      securityFramework,
+      metricsCollector,
+      resilientWrapper,
+      useCaseRouter,
+      sessionManager,
+      calculateSystemHealth,
+    } = this.deps;
+
+    const traceSpan = metricsCollector.startOperation(operationId, request.type, {
+      sessionId: request.session?.id,
+    });
+
+    try {
+      const securityValidation = await securityFramework.validateOperation(
+        JSON.stringify(request.input),
+        { operationType: request.type, sessionId: request.session?.id }
+      );
+
+      if (!securityValidation.allowed) {
+        logger.warn(
+          `🚫 Security validation failed for operation ${operationId}:`,
+          securityValidation.violations
+        );
+
+        metricsCollector.recordOperation(
+          operationId,
+          false,
+          `Security validation failed: ${securityValidation.violations.join(', ')}`,
+          undefined,
+          traceSpan
+        );
+
+        return {
+          id: operationId,
+          success: false,
+          error: `Security validation failed: ${securityValidation.violations.join(', ')}`,
+          metrics: {
+            processingTime: performance.now() - startTime,
+            contextConfidence: 0,
+            systemHealth: calculateSystemHealth(),
+          },
+        };
+      }
+
+      const resilientResult = await resilientWrapper.executeWithRecovery(
+        async () => {
+          const routerRequest = {
+            ...request,
+            input: typeof request.input === 'string' ? request.input : '',
+          };
+          return useCaseRouter.executeOperation(routerRequest);
+        },
+        {
+          name: `CLI-${request.type}`,
+          component: 'UnifiedCLICoordinator',
+          critical: request.type === 'execute',
+        },
+        {
+          enableGracefulDegradation: options.enableGracefulDegradation,
+          retryAttempts: options.retryAttempts,
+          timeoutMs: options.timeoutMs,
+          fallbackMode: options.fallbackMode,
+          errorNotification: options.errorNotification,
+        }
+      );
+
+      const processingTime = performance.now() - startTime;
+
+      metricsCollector.recordOperation(
+        operationId,
+        resilientResult.success,
+        resilientResult.error,
+        { recoveryActions: resilientResult.metrics?.recoveryActions || 0 },
+        traceSpan
+      );
+
+      if (request.session?.id) {
+        sessionManager.updateSessionMetrics(request.session.id, {
+          commandsExecuted: 1,
+          contextEnhancements: 1,
+          errorsRecovered: resilientResult.metrics?.recoveryActions || 0,
+          totalProcessingTime: processingTime,
+        });
+      }
+
+      return {
+        id: operationId,
+        success: resilientResult.success,
+        result: resilientResult.data,
+        error: resilientResult.error,
+        enhancements: {
+          contextAdded: true,
+          performanceOptimized: true,
+          errorsRecovered: resilientResult.metrics?.recoveryActions || 0,
+        },
+        metrics: {
+          processingTime,
+          contextConfidence: 0.8,
+          systemHealth: calculateSystemHealth(),
+        },
+      };
+    } catch (error) {
+      const processingTime = performance.now() - startTime;
+
+      metricsCollector.recordOperation(
+        operationId,
+        false,
+        (error as Error).message,
+        undefined,
+        traceSpan
+      );
+
+      logger.error(`CLI operation ${operationId} failed:`, error);
+
+      return {
+        id: operationId,
+        success: false,
+        error: (error as Error).message,
+        metrics: {
+          processingTime,
+          contextConfidence: 0,
+          systemHealth: calculateSystemHealth(),
+        },
+      };
+    }
+  }
+}
+
+export default CLIOrchestrator;

--- a/src/application/services/cli/command-parser.ts
+++ b/src/application/services/cli/command-parser.ts
@@ -1,0 +1,18 @@
+import { randomUUID } from 'crypto';
+import type { CLIOperationRequest } from '../unified-cli-coordinator.js';
+
+export interface ICLIParser {
+  parse(args: readonly string[]): CLIOperationRequest;
+}
+
+export class CLICommandParser implements ICLIParser {
+  public parse(args: readonly string[]): CLIOperationRequest {
+    return {
+      id: randomUUID(),
+      type: 'prompt',
+      input: args.join(' '),
+    } as CLIOperationRequest;
+  }
+}
+
+export default CLICommandParser;

--- a/src/application/services/cli/resilience-manager.ts
+++ b/src/application/services/cli/resilience-manager.ts
@@ -1,17 +1,25 @@
 import { EventEmitter } from 'events';
 import { ResilientCLIWrapper } from '../../../infrastructure/resilience/resilient-cli-wrapper.js';
 
-/**
- * Wire resilient wrapper events to the provided emitter.
- */
-export function setupResilienceEvents(wrapper: ResilientCLIWrapper, emitter: EventEmitter): void {
-  wrapper.on('critical_error', data => {
-    emitter.emit('error:critical', data);
-  });
+export class CLIResilienceManager {
+  public constructor(private readonly wrapper: ResilientCLIWrapper) {}
 
-  wrapper.on('system_overload', data => {
-    emitter.emit('error:overload', data);
-  });
+  public wire(emitter: EventEmitter): void {
+    this.wrapper.on('critical_error', data => {
+      emitter.emit('error:critical', data);
+    });
+    this.wrapper.on('system_overload', data => {
+      emitter.emit('error:overload', data);
+    });
+  }
+
+  public getWrapper(): ResilientCLIWrapper {
+    return this.wrapper;
+  }
+
+  public shutdown(): void {
+    this.wrapper.shutdown();
+  }
 }
 
-export default setupResilienceEvents;
+export default CLIResilienceManager;

--- a/tests/integration/cli-modules.integration.test.ts
+++ b/tests/integration/cli-modules.integration.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from '@jest/globals';
+import { UnifiedCLICoordinator } from '../../src/application/services/unified-cli-coordinator.js';
+import { CLIResilienceManager } from '../../src/application/services/cli/resilience-manager.js';
+import { ResilientCLIWrapper } from '../../src/infrastructure/resilience/resilient-cli-wrapper.js';
+import type { ICLIParser } from '../../src/application/services/cli/command-parser.js';
+import type { ICLIOrchestrator } from '../../src/application/services/cli/cli-orchestrator.js';
+import type {
+  CLIOperationRequest,
+  CLIOperationResponse,
+  UnifiedCLIOptions,
+} from '../../src/application/services/unified-cli-coordinator.js';
+
+class TestParser implements ICLIParser {
+  public parse(_args: readonly string[]): CLIOperationRequest {
+    return { id: '1', type: 'prompt', input: 'hi' };
+  }
+}
+
+class TestOrchestrator implements ICLIOrchestrator {
+  public lastRequest: CLIOperationRequest | undefined;
+  public async processOperation(
+    request: Readonly<CLIOperationRequest>,
+    _options: UnifiedCLIOptions
+  ): Promise<CLIOperationResponse> {
+    this.lastRequest = request as CLIOperationRequest;
+    return {
+      id: request.id,
+      success: true,
+      metrics: { processingTime: 0, contextConfidence: 0, systemHealth: 1 },
+    };
+  }
+}
+
+describe('Unified CLI modular components', () => {
+  it('wires parser and orchestrator via dependency injection', async () => {
+    const parser = new TestParser();
+    const orchestrator = new TestOrchestrator();
+    const resilienceManager = new CLIResilienceManager(new ResilientCLIWrapper());
+    const coordinator = new UnifiedCLICoordinator(
+      {},
+      {
+        parser,
+        resilienceManager,
+        orchestrator,
+      }
+    );
+
+    await coordinator.initialize({
+      orchestrator: {} as any,
+      userInteraction: { display: async () => {} } as any,
+      eventBus: { emit: () => {}, on: () => {} } as any,
+    });
+
+    await coordinator.executeFromArgs(['test']);
+    expect(orchestrator.lastRequest?.input).toBe('hi');
+  });
+});


### PR DESCRIPTION
## Summary
- extract CLICommandParser and CLIResilienceManager for dedicated parsing and error handling
- add CLIOrchestrator and wire UnifiedCLICoordinator through dependency injection
- exercise parser and orchestrator via new CLI integration test

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run format`
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest')*
- `npm test` *(fails: Cannot find module 'node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68bce066015c832daa67480306a02e2e