### PR TITLE
refactor: modularize workflow orchestrator dependencies

### DIFF
--- a/src/application/services/orchestrator/streaming-manager.ts
+++ b/src/application/services/orchestrator/streaming-manager.ts
@@ -1,14 +1,15 @@
-import {
+import type {
   IModelClient,
   ModelRequest,
   ModelResponse,
 } from '../../../domain/interfaces/model-client.js';
+import type { IStreamingManager } from '../../../domain/interfaces/streaming-manager.js';
 import { executeWithStreaming } from './streaming-handler.js';
 
 /**
  * StreamingManager delegates streaming execution for model requests.
  */
-export class StreamingManager {
+export class StreamingManager implements IStreamingManager {
   async stream(modelClient: IModelClient, request: ModelRequest): Promise<ModelResponse> {
     return executeWithStreaming(modelClient, request);
   }

--- a/src/application/services/orchestrator/tool-execution-router.ts
+++ b/src/application/services/orchestrator/tool-execution-router.ts
@@ -1,6 +1,7 @@
-import { WorkflowRequest } from '../../../domain/interfaces/workflow-orchestrator.js';
-import { ModelRequest, ModelResponse } from '../../../domain/interfaces/model-client.js';
-import { IMcpManager } from '../../../domain/interfaces/mcp-manager.js';
+import type { WorkflowRequest } from '../../../domain/interfaces/workflow-orchestrator.js';
+import type { ModelRequest, ModelResponse } from '../../../domain/interfaces/model-client.js';
+import type { IMcpManager } from '../../../domain/interfaces/mcp-manager.js';
+import type { IToolExecutionRouter } from '../../../domain/interfaces/tool-execution-router.js';
 import { logger } from '../../../infrastructure/logging/logger.js';
 import { getErrorMessage } from '../../../utils/error-utils.js';
 import { getGlobalEnhancedToolIntegration } from '../../../infrastructure/tools/enhanced-tool-integration.js';
@@ -8,7 +9,7 @@ import { getGlobalEnhancedToolIntegration } from '../../../infrastructure/tools/
 /**
  * Routes tool execution requests and handles follow-up model synthesis.
  */
-export class ToolExecutionRouter {
+export class ToolExecutionRouter implements IToolExecutionRouter {
   public constructor(private readonly mcpManager: IMcpManager) {}
 
   public async handleToolCalls(

--- a/src/application/services/provider-capability-registry.ts
+++ b/src/application/services/provider-capability-registry.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IProviderCapabilityRegistry,
   ProviderCapability,
 } from '../../domain/interfaces/provider-capability-registry.js';

--- a/src/domain/interfaces/index.ts
+++ b/src/domain/interfaces/index.ts
@@ -15,3 +15,5 @@ export * from './mcp-manager.js';
 export * from './tool-system.js';
 export * from './configuration.js';
 export * from './provider-capability-registry.js';
+export * from './streaming-manager.js';
+export * from './tool-execution-router.js';

--- a/src/domain/interfaces/streaming-manager.ts
+++ b/src/domain/interfaces/streaming-manager.ts
@@ -1,0 +1,5 @@
+import type { IModelClient, ModelRequest, ModelResponse } from './model-client.js';
+
+export interface IStreamingManager {
+  stream(modelClient: IModelClient, request: ModelRequest): Promise<ModelResponse>;
+}

--- a/src/domain/interfaces/tool-execution-router.ts
+++ b/src/domain/interfaces/tool-execution-router.ts
@@ -1,0 +1,11 @@
+import type { WorkflowRequest } from './workflow-orchestrator.js';
+import type { ModelRequest, ModelResponse } from './model-client.js';
+
+export interface IToolExecutionRouter {
+  handleToolCalls(
+    response: Readonly<ModelResponse>,
+    request: Readonly<WorkflowRequest>,
+    modelRequest: Readonly<ModelRequest>,
+    processModelRequest: (req: Readonly<ModelRequest>) => Promise<ModelResponse>
+  ): Promise<ModelResponse>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,18 +11,13 @@ import { config } from 'dotenv';
 config();
 
 import { CLIOptions, UnifiedCLI } from './application/interfaces/unified-cli.js';
-import { ConcreteWorkflowOrchestrator } from './application/services/concrete-workflow-orchestrator.js';
 import { CLIUserInteraction } from './infrastructure/user-interaction/cli-user-interaction.js';
 import { createAdaptersFromProviders } from './application/services/adapter-factory.js';
 // getGlobalEventBus intentionally not imported anymore – event bus is injected via RuntimeContext.
 import { getErrorMessage } from './utils/error-utils.js';
 import { logger } from './infrastructure/logging/logger.js';
-import {
-  enterpriseErrorHandler,
-} from './infrastructure/error-handling/enterprise-error-handler.js';
-import {
-  ErrorSeverity,
-} from './infrastructure/error-handling/structured-error-system.js';
+import { enterpriseErrorHandler } from './infrastructure/error-handling/enterprise-error-handler.js';
+import { ErrorSeverity } from './infrastructure/error-handling/structured-error-system.js';
 
 import { Command } from 'commander';
 import { readFile } from 'fs/promises';
@@ -123,15 +118,15 @@ export async function initialize(
       // Create a new EnhancedToolIntegration with the correct config shape
       const enhancedIntegration = new EnhancedToolIntegration({});
       // If EnhancedToolIntegration needs mcpServerManager, set it after construction
-      if ('setMcpServerManager' in enhancedIntegration && typeof enhancedIntegration.setMcpServerManager === 'function') {
+      if (
+        'setMcpServerManager' in enhancedIntegration &&
+        typeof enhancedIntegration.setMcpServerManager === 'function'
+      ) {
         enhancedIntegration.setMcpServerManager(mcpServerManager);
       }
       setGlobalEnhancedToolIntegration(enhancedIntegration);
       logger.info('✅ Enhanced tool integration initialized');
     }
-
-    // Create ConcreteWorkflowOrchestrator (implements IWorkflowOrchestrator interface)
-    const orchestrator = new ConcreteWorkflowOrchestrator();
 
     // Initialize proper UnifiedModelClient with dynamic model selection
     const { UnifiedModelClient } = await import('./application/services/model-client.js');
@@ -228,26 +223,31 @@ export async function initialize(
       const adapter: Adapter = {} as Adapter;
 
       // copy own enumerable properties
-      Object.keys(userInteraction).forEach((key) => {
+      Object.keys(userInteraction).forEach(key => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        adapter[key] = ((userInteraction as unknown) as Record<string, unknown>)[key];
+        adapter[key] = (userInteraction as unknown as Record<string, unknown>)[key];
       });
 
       // copy prototype methods
       const proto = Object.getPrototypeOf(userInteraction) as object;
-      Object.getOwnPropertyNames(proto).forEach((name) => {
+      Object.getOwnPropertyNames(proto).forEach(name => {
         if (name === 'constructor') return;
         const desc = Object.getOwnPropertyDescriptor(proto, name);
         if (desc && typeof desc.value === 'function') {
           adapter[name] = (...args: readonly unknown[]): unknown =>
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            ((userInteraction as unknown) as Record<string, (...args: readonly unknown[]) => unknown>)[name](...args);
+            (
+              userInteraction as unknown as Record<string, (...args: readonly unknown[]) => unknown>
+            )[name](...args);
         }
       });
 
       // Override select to accept readonly choices and delegate to the mutable implementation
       adapter.select = async (question: string, choices: readonly string[]): Promise<string> =>
-        (userInteraction.select as (q: string, c: string[]) => Promise<string>)(question, Array.from(choices));
+        (userInteraction.select as (q: string, c: string[]) => Promise<string>)(
+          question,
+          Array.from(choices)
+        );
 
       return adapter;
     })();
@@ -259,7 +259,10 @@ export async function initialize(
           type MCPServerManagerAdapter = {
             [K in keyof MCPServerManagerType]: MCPServerManagerType[K];
           } & {
-            executeCommandSecure: (command: string, args?: readonly string[] | undefined) => Promise<string>;
+            executeCommandSecure: (
+              command: string,
+              args?: readonly string[] | undefined
+            ) => Promise<string>;
             [key: string]: unknown;
           };
           const adapter: MCPServerManagerAdapter = {} as MCPServerManagerAdapter;
@@ -271,7 +274,12 @@ export async function initialize(
             if (desc && typeof desc.value === 'function') {
               adapter[name] = (...args: readonly unknown[]): unknown =>
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                ((mcpServerManager as unknown) as Record<string, (...args: readonly unknown[]) => unknown>)[name](...args);
+                (
+                  mcpServerManager as unknown as Record<
+                    string,
+                    (...args: readonly unknown[]) => unknown
+                  >
+                )[name](...args);
             }
           });
 
@@ -279,19 +287,25 @@ export async function initialize(
             command: string,
             args?: readonly string[] | undefined
           ): Promise<string> =>
-            (mcpServerManager.executeCommandSecure as (c: string, a?: readonly string[] | undefined) => Promise<string>)(
-              command,
-              args ? Array.from(args) : undefined
-            );
+            (
+              mcpServerManager.executeCommandSecure as (
+                c: string,
+                a?: readonly string[] | undefined
+              ) => Promise<string>
+            )(command, args ? Array.from(args) : undefined);
 
           return adapter;
         })()
       : undefined;
+    const orchestrator = serviceFactory.createWorkflowOrchestrator(
+      mcpManagerAdapter as unknown as import('./domain/interfaces/mcp-manager.js').IMcpManager
+    );
 
     // Cast to unknown to bridge minor shape differences at compile-time;
     // adapters delegate to the real instances at runtime so behavior is preserved.
     await orchestrator.initialize({
-      userInteraction: userInteractionAdapter as unknown as import('./domain/interfaces/user-interaction.js').IUserInteraction,
+      userInteraction:
+        userInteractionAdapter as unknown as import('./domain/interfaces/user-interaction.js').IUserInteraction,
       eventBus,
       modelClient,
       mcpManager: mcpManagerAdapter
@@ -568,19 +582,21 @@ program
   .option('-l, --list', 'List all available models')
   .option('-s, --select', 'Interactive model selection')
   .option('-i, --interactive', 'Same as --select')
-  .action(async (options: Readonly<{ list?: boolean; select?: boolean; interactive?: boolean }>) => {
-    const { ModelsCommand } = await import('./application/cli/models-command.js');
-    const modelsCommand = new ModelsCommand();
+  .action(
+    async (options: Readonly<{ list?: boolean; select?: boolean; interactive?: boolean }>) => {
+      const { ModelsCommand } = await import('./application/cli/models-command.js');
+      const modelsCommand = new ModelsCommand();
 
-    // Convert Commander options to models command options
-    const modelsOptions = {
-      list: !!options.list,
-      select: !!options.select || !!options.interactive,
-      interactive: !!options.interactive,
-    };
+      // Convert Commander options to models command options
+      const modelsOptions = {
+        list: !!options.list,
+        select: !!options.select || !!options.interactive,
+        interactive: !!options.interactive,
+      };
 
-    await modelsCommand.execute(modelsOptions);
-  });
+      await modelsCommand.execute(modelsOptions);
+    }
+  );
 
 // Add status command to Commander program
 program

--- a/tests/unit/application/orchestrator/provider-capability-registry.test.ts
+++ b/tests/unit/application/orchestrator/provider-capability-registry.test.ts
@@ -1,0 +1,10 @@
+import { ProviderCapabilityRegistry } from '../../../../src/application/services/provider-capability-registry.js';
+
+describe('ProviderCapabilityRegistry', () => {
+  it('registers and checks capabilities', () => {
+    const registry = new ProviderCapabilityRegistry();
+    registry.register('test', { streaming: true, toolCalling: false });
+    expect(registry.supports('test', 'streaming')).toBe(true);
+    expect(registry.supports('test', 'toolCalling')).toBe(false);
+  });
+});

--- a/tests/unit/application/orchestrator/streaming-manager.test.ts
+++ b/tests/unit/application/orchestrator/streaming-manager.test.ts
@@ -1,0 +1,24 @@
+import { StreamingManager } from '../../../../src/application/services/orchestrator/streaming-manager.js';
+import type {
+  IModelClient,
+  ModelRequest,
+  ModelResponse,
+} from '../../../../src/domain/interfaces/model-client.js';
+
+jest.mock('../../../../src/application/services/orchestrator/streaming-handler.js', () => ({
+  executeWithStreaming: jest.fn(async () => ({ content: 'ok' }) as ModelResponse),
+}));
+
+const { executeWithStreaming } = jest.requireMock(
+  '../../../../src/application/services/orchestrator/streaming-handler.js'
+) as { executeWithStreaming: jest.Mock };
+
+describe('StreamingManager', () => {
+  it('delegates to executeWithStreaming', async () => {
+    const manager = new StreamingManager();
+    const mockClient = {} as IModelClient;
+    const request = { stream: true } as ModelRequest;
+    await manager.stream(mockClient, request);
+    expect(executeWithStreaming).toHaveBeenCalledWith(mockClient, request);
+  });
+});

--- a/tests/unit/application/orchestrator/tool-execution-router.test.ts
+++ b/tests/unit/application/orchestrator/tool-execution-router.test.ts
@@ -1,0 +1,26 @@
+import { ToolExecutionRouter } from '../../../../src/application/services/orchestrator/tool-execution-router.js';
+import type { IMcpManager } from '../../../../src/domain/interfaces/mcp-manager.js';
+import type { WorkflowRequest } from '../../../../src/domain/interfaces/workflow-orchestrator.js';
+import type {
+  ModelRequest,
+  ModelResponse,
+} from '../../../../src/domain/interfaces/model-client.js';
+
+describe('ToolExecutionRouter', () => {
+  it('returns original response when no tool calls', async () => {
+    const mcpManager = { executeTool: jest.fn() } as unknown as IMcpManager;
+    const router = new ToolExecutionRouter(mcpManager);
+    const response = { content: 'hi' } as ModelResponse;
+    const request = { payload: { input: 'hello' } } as WorkflowRequest;
+    const modelRequest = {} as ModelRequest;
+    const processModelRequest = jest.fn();
+    const result = await router.handleToolCalls(
+      response,
+      request,
+      modelRequest,
+      processModelRequest
+    );
+    expect(result).toBe(response);
+    expect(mcpManager.executeTool).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- refactor ConcreteWorkflowOrchestrator to inject streaming manager, tool router, and capability registry
- add interfaces for streaming and tool routing modules and expose via service factory
- cover new modules with focused unit tests

## Testing
- `npm run lint:fix`
- `npx prettier -w src/application/services/concrete-workflow-orchestrator.ts src/application/services/orchestrator/streaming-manager.ts src/application/services/orchestrator/tool-execution-router.ts src/application/services/provider-capability-registry.ts src/application/services/service-factory.ts src/domain/interfaces/index.ts src/domain/interfaces/streaming-manager.ts src/domain/interfaces/tool-execution-router.ts src/index.ts tests/unit/application/orchestrator/streaming-manager.test.ts tests/unit/application/orchestrator/tool-execution-router.test.ts tests/unit/application/orchestrator/provider-capability-registry.test.ts`
- `npm run typecheck`
- `npm run test:unit` *(fails: Cannot find module '../../../../src/core/agents/agent-communication-protocol.js' from 'tests/unit/core/agents/agent-communication-protocol.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68bce0605114832db84751ae460a649f