### PR TITLE
refactor(cli): centralize request normalization

### DIFF
--- a/src/application/cli/use-case-router.ts
+++ b/src/application/cli/use-case-router.ts
@@ -30,7 +30,7 @@ import {
 export interface CLIOperationRequest {
   id: string;
   type: 'prompt' | 'analyze' | 'execute' | 'navigate' | 'suggest';
-  input: unknown;
+  input: string | object;
   options?: UseCaseRouterOptions;
   session?: {
     id: string;

--- a/src/application/cli/use-case-router.ts
+++ b/src/application/cli/use-case-router.ts
@@ -30,12 +30,12 @@ import {
 export interface CLIOperationRequest {
   id: string;
   type: 'prompt' | 'analyze' | 'execute' | 'navigate' | 'suggest';
-  input: string;
+  input: unknown;
   options?: UseCaseRouterOptions;
   session?: {
     id: string;
-    workingDirectory: string;
-    context: WorkflowContext;
+    workingDirectory?: string;
+    context?: WorkflowContext;
   };
 }
 

--- a/src/application/services/cli/cli-orchestrator.ts
+++ b/src/application/services/cli/cli-orchestrator.ts
@@ -83,13 +83,7 @@ export class CLIOrchestrator implements ICLIOrchestrator {
       }
 
       const resilientResult = await resilientWrapper.executeWithRecovery(
-        async () => {
-          const routerRequest = {
-            ...request,
-            input: typeof request.input === 'string' ? request.input : '',
-          };
-          return useCaseRouter.executeOperation(routerRequest);
-        },
+        async () => useCaseRouter.executeOperation(request),
         {
           name: `CLI-${request.type}`,
           component: 'UnifiedCLICoordinator',

--- a/src/application/services/cli/command-parser.ts
+++ b/src/application/services/cli/command-parser.ts
@@ -7,11 +7,13 @@ export interface ICLIParser {
 
 export class CLICommandParser implements ICLIParser {
   public parse(args: readonly string[]): CLIOperationRequest {
-    return {
+    const request: CLIOperationRequest = {
       id: randomUUID(),
       type: 'prompt',
       input: args.join(' '),
     };
+
+    return request;
   }
 }
 


### PR DESCRIPTION
## Summary
- allow UseCaseRouter to handle unknown input and optional session properties
- delegate CLIOrchestrator directly to UseCaseRouter without manual coercion
- build typed CLIOperationRequest in CLICommandParser without assertions

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run format`
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest')*
- `npm test` *(fails: Cannot find module 'node_modules/jest/bin/jest.js')*


------
https://chatgpt.com/codex/tasks/task_e_68bce3085dac832d8b1f32be1af8858e