### PR TITLE
fix(production): restore integration manager API

### DIFF
--- a/src/infrastructure/production/deployment-orchestrator.ts
+++ b/src/infrastructure/production/deployment-orchestrator.ts
@@ -1,7 +1,4 @@
-import {
-  IntegratedSystemHealth,
-  ProductionIntegrationConfig,
-} from './production-types.js';
+import { IntegratedSystemHealth, ProductionIntegrationConfig } from './production-types.js';
 import { EnvironmentManager } from './environment-manager.js';
 import { HealthMonitoring } from './health-monitoring.js';
 import { ScalingCoordinator } from './scaling-coordinator.js';
@@ -10,11 +7,28 @@ import { BackupCoordinator } from './backup-coordinator.js';
 import { MetricsCollector } from './metrics-collector.js';
 import { RollbackManager } from './rollback-manager.js';
 
+interface RetryConfig {
+  attempts: number;
+  delayMs: number;
+}
+
+interface CircuitBreakerConfig {
+  threshold: number;
+  delayMs: number;
+}
+
+export interface DeploymentOrchestratorOptions {
+  retry?: RetryConfig;
+  circuitBreaker?: CircuitBreakerConfig;
+}
+
 export class DeploymentOrchestrator {
   private failureCount = 0;
   private circuitOpen = false;
-  private readonly breakerThreshold = 5;
-  private readonly breakerDelay = 30_000;
+  private readonly breakerThreshold: number;
+  private readonly breakerDelay: number;
+  private readonly retryAttempts: number;
+  private readonly retryDelay: number;
 
   constructor(
     private readonly env: EnvironmentManager,
@@ -24,7 +38,13 @@ export class DeploymentOrchestrator {
     private readonly backup: BackupCoordinator,
     private readonly metrics: MetricsCollector,
     private readonly rollback: RollbackManager,
-  ) {}
+    options: DeploymentOrchestratorOptions = {}
+  ) {
+    this.retryAttempts = options.retry?.attempts ?? 3;
+    this.retryDelay = options.retry?.delayMs ?? 500;
+    this.breakerThreshold = options.circuitBreaker?.threshold ?? 5;
+    this.breakerDelay = options.circuitBreaker?.delayMs ?? 30_000;
+  }
 
   async deploy(config: ProductionIntegrationConfig): Promise<IntegratedSystemHealth> {
     return this.circuitBreaker(async () =>
@@ -34,18 +54,22 @@ export class DeploymentOrchestrator {
         await this.backup.backup();
         await this.metrics.collect();
         return this.health.checkHealth();
-      }),
+      })
     );
   }
 
-  private async executeWithRetry<T>(fn: () => Promise<T>, retries = 3, delay = 500): Promise<T> {
+  private async executeWithRetry<T>(
+    fn: () => Promise<T>,
+    retries = this.retryAttempts,
+    delay = this.retryDelay
+  ): Promise<T> {
     try {
       return await fn();
     } catch (err) {
       if (retries <= 0) {
         throw err;
       }
-      await new Promise((resolve) => setTimeout(resolve, delay));
+      await new Promise(resolve => setTimeout(resolve, delay));
       return this.executeWithRetry(fn, retries - 1, delay * 2);
     }
   }

--- a/src/infrastructure/production/production-integration-manager.ts
+++ b/src/infrastructure/production/production-integration-manager.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'events';
 import { ProductionIntegrationConfig, IntegratedSystemHealth } from './production-types.js';
 import { DeploymentOrchestrator } from './deployment-orchestrator.js';
 import { EnvironmentManager } from './environment-manager.js';
@@ -8,29 +9,65 @@ import { BackupCoordinator } from './backup-coordinator.js';
 import { MetricsCollector } from './metrics-collector.js';
 import { RollbackManager } from './rollback-manager.js';
 
-export class ProductionIntegrationManager {
+export class ProductionIntegrationManager extends EventEmitter {
+  private static instance?: ProductionIntegrationManager;
   private readonly orchestrator: DeploymentOrchestrator;
+  private readonly env: EnvironmentManager;
+  private readonly health: HealthMonitoring;
 
-  constructor(private readonly config: ProductionIntegrationConfig) {
-    const env = new EnvironmentManager(config);
-    const health = new HealthMonitoring();
+  private constructor(private readonly config: ProductionIntegrationConfig) {
+    super();
+    this.env = new EnvironmentManager(config);
+    this.health = new HealthMonitoring();
     const scaling = new ScalingCoordinator();
     const security = new SecurityIntegration();
     const backup = new BackupCoordinator();
     const metrics = new MetricsCollector();
     const rollback = new RollbackManager();
     this.orchestrator = new DeploymentOrchestrator(
-      env,
-      health,
+      this.env,
+      this.health,
       scaling,
       security,
       backup,
       metrics,
-      rollback,
+      rollback
     );
   }
 
+  static getInstance(config: ProductionIntegrationConfig): ProductionIntegrationManager {
+    if (!this.instance) {
+      this.instance = new ProductionIntegrationManager(config);
+    }
+    return this.instance;
+  }
+
+  async initializeProductionSystem(): Promise<void> {
+    this.emit('initialize:start');
+    await this.getIntegratedSystemHealth();
+    this.emit('initialize:completed');
+  }
+
+  async getIntegratedSystemHealth(): Promise<IntegratedSystemHealth> {
+    const health = await this.health.checkHealth();
+    this.emit('health-check-completed', health);
+    if (health.overallStatus === 'emergency') {
+      this.emit('emergency:activated', health);
+    }
+    return health;
+  }
+
+  async shutdownProductionSystem(): Promise<void> {
+    this.emit('shutdown:start');
+    this.emit('shutdown:completed');
+  }
+
   async executeWithProductionHardening(): Promise<IntegratedSystemHealth> {
-    return this.orchestrator.deploy(this.config);
+    try {
+      return await this.orchestrator.deploy(this.config);
+    } catch (error) {
+      this.emit('operation-failed', { context: { operationId: 'deploy' }, error });
+      throw error;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- restore `ProductionIntegrationManager` singleton/event API with initialization, health, shutdown, and hardened execution methods
- make `DeploymentOrchestrator` retry and circuit breaker settings configurable

## Testing
- `npx eslint src/infrastructure/production/production-integration-manager.ts src/infrastructure/production/deployment-orchestrator.ts --fix` *(fails: Cannot find package '@eslint/js')*
- `npx prettier src/infrastructure/production/production-integration-manager.ts src/infrastructure/production/deployment-orchestrator.ts -w`
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest')*
- `npm test` *(fails: Cannot find module 'node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68bceb42f6ac832d87a018a678aa2c53