### PR TITLE
fix(routing): restore failsafe decision handling

### DIFF
--- a/src/application/routing/intelligent-routing-coordinator.ts
+++ b/src/application/routing/intelligent-routing-coordinator.ts
@@ -13,11 +13,19 @@ import { RoutingDecisionEngine } from './routing-decision-engine.js';
 import { ModelSelectionCoordinator } from './model-selection-coordinator.js';
 import { VoiceIntegrationHandler } from './voice-integration-handler.js';
 import { RoutingPerformanceMonitor } from './routing-performance-monitor.js';
-import { IModelSelectionService } from '../../domain/services/model-selection-service.js';
-import { IVoiceOrchestrationService } from '../../domain/services/voice-orchestration-service.js';
+import {
+  IModelSelectionService,
+  RoutingStrategy,
+} from '../../domain/services/model-selection-service.js';
+import {
+  IVoiceOrchestrationService,
+  SynthesisMode,
+} from '../../domain/services/voice-orchestration-service.js';
 import { IProviderSelectionStrategy } from '../../providers/provider-selection-strategy.js';
 import { HybridLLMRouter } from '../../providers/hybrid/hybrid-llm-router.js';
 import { PerformanceMonitor } from '../../utils/performance.js';
+import { Model } from '../../domain/entities/model.js';
+import { Voice } from '../../domain/entities/voice.js';
 
 const logger = createLogger('IntelligentRoutingCoordinator');
 
@@ -62,11 +70,65 @@ export class IntelligentRoutingCoordinator
       return Object.freeze(cloned);
     }
 
-    const decision = await this.decisionEngine.makeDecision(context, routingId);
-    this.cache.set(context, decision);
-    this.analytics.addDecision(routingId, decision);
-    this.emit('routingDecision', decision);
-    return decision;
+    try {
+      const decision = await this.decisionEngine.makeDecision(context, routingId);
+      this.cache.set(context, decision);
+      this.analytics.addDecision(routingId, decision);
+      this.emit('routingDecision', decision);
+      return decision;
+    } catch (error) {
+      logger.error('Routing decision failed, returning failsafe decision', error);
+      const failsafeDecision: IntelligentRoutingDecision = Object.freeze({
+        modelSelection: {
+          primaryModel: {
+            name: { value: 'fallback-model' },
+            providerType: 'lm-studio',
+          } as unknown as Model,
+          fallbackModels: [],
+          selectionReason: 'Failsafe model selection',
+          routingStrategy: RoutingStrategy.SHARED,
+          estimatedCost: 0,
+          estimatedLatency: 0,
+        },
+        voiceSelection: {
+          primaryVoice: {
+            id: 'guardian',
+            name: 'Failsafe Voice',
+            expertise: [],
+            languages: [],
+            isActive: true,
+          } as unknown as Voice,
+          supportingVoices: [],
+          synthesisMode: SynthesisMode.SINGLE,
+          reasoning: 'Failsafe voice selection',
+        },
+        providerSelection: {
+          provider: 'lm-studio',
+          reason: 'Failsafe provider',
+          confidence: 0,
+          fallbackChain: [],
+        },
+        routingStrategy: 'single-model',
+        confidence: 0.3,
+        reasoning: `Failsafe decision due to error: ${(error as Error).message}`,
+        estimatedCost: 0,
+        estimatedLatency: 0,
+        estimatedQuality: 0,
+        fallbackChain: [
+          {
+            type: 'model',
+            option: 'fallback-model',
+            reason: 'Default failsafe model',
+          },
+        ],
+        routingId,
+        timestamp: Date.now(),
+        context,
+      });
+      this.analytics.addDecision(routingId, failsafeDecision);
+      this.emit('routingDecision', failsafeDecision);
+      return failsafeDecision;
+    }
   }
 
   public recordPerformance(routingId: string, performance: Readonly<RoutingPerformance>): void {

--- a/src/application/routing/intelligent-routing-coordinator.ts
+++ b/src/application/routing/intelligent-routing-coordinator.ts
@@ -83,7 +83,16 @@ export class IntelligentRoutingCoordinator
           primaryModel: {
             name: { value: 'fallback-model' },
             providerType: 'lm-studio',
-          } as unknown as Model,
+            // Add other required Model properties with failsafe defaults
+            // If Model is an interface, add all required fields here
+            // If Model is a class, instantiate it if possible
+            // The following are common Model fields; adjust as needed
+            id: 'fallback-model',
+            version: '1.0.0',
+            description: 'Failsafe fallback model',
+            isActive: true,
+            // Add more fields if Model requires them
+          },
           fallbackModels: [],
           selectionReason: 'Failsafe model selection',
           routingStrategy: RoutingStrategy.SHARED,


### PR DESCRIPTION
## Summary
- ensure intelligent routing coordinator falls back to a failsafe decision when routing fails
- standardize logging to use shared logger module

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run format`
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest', 'node')*
- `npm test` *(fails: Cannot find module '.../node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68bcec0a2a94832d94dea162a8819893