### PR TITLE
fix(ollama): improve error handling and typing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,6 +101,7 @@
         "tar": "^7.4.3",
         "terminal-link": "^3.0.0",
         "tree-kill": "^1.2.2",
+        "undici": "^5.29.0",
         "update-notifier": "^7.0.0",
         "winston": "^3.17.0",
         "wrap-ansi": "^9.0.0",
@@ -3666,6 +3667,15 @@
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@gar/promisify": {
@@ -26914,6 +26924,18 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
     "tar": "^7.4.3",
     "terminal-link": "^3.0.0",
     "tree-kill": "^1.2.2",
+    "undici": "^5.29.0",
     "update-notifier": "^7.0.0",
     "winston": "^3.17.0",
     "wrap-ansi": "^9.0.0",

--- a/src/providers/hybrid/ollama-http-client.ts
+++ b/src/providers/hybrid/ollama-http-client.ts
@@ -1,12 +1,15 @@
-import { Agent } from 'undici';
+import { Agent, fetch } from 'undici';
 
 export class OllamaHttpClient {
   private readonly baseUrl: string;
   private readonly agent: Agent;
 
-  public constructor(baseUrl: string) {
+  public constructor(baseUrl: string, maxConnections = 10) {
     this.baseUrl = baseUrl;
-    this.agent = new Agent({ keepAliveTimeout: 60_000, connections: 100 });
+    this.agent = new Agent({
+      keepAliveTimeout: 60_000,
+      connections: maxConnections,
+    });
   }
 
   public async get<T>(path: string, signal?: AbortSignal): Promise<T> {
@@ -32,6 +35,6 @@ export class OllamaHttpClient {
       },
       signal,
     });
-    return response;
+    return response as unknown as Response;
   }
 }

--- a/src/providers/hybrid/ollama-provider.ts
+++ b/src/providers/hybrid/ollama-provider.ts
@@ -5,12 +5,33 @@ import {
   LLMStatus,
   LLMResponse,
 } from '../../domain/interfaces/llm-interfaces.js';
-import { OllamaConfig, OllamaRequest, parseEnvInt } from './ollama-config.js';
+import {
+  OllamaConfig,
+  OllamaMessage,
+  OllamaRequest,
+  OllamaStreamingMetadata,
+  ParsedToolCall,
+  parseEnvInt,
+} from './ollama-config.js';
 import { OllamaHttpClient } from './ollama-http-client.js';
 import { handleStreaming } from './ollama-streaming-handler.js';
 import { extractToolCalls } from './ollama-tool-processor.js';
 import { parseResponse } from './ollama-response-parser.js';
 import { generateContextualSystemPrompt } from '../../domain/prompts/system-prompt.js';
+
+interface GenerateCodeOptions extends Record<string, unknown> {
+  model?: string;
+  onStreamingToken?: (token: string, metadata?: OllamaStreamingMetadata) => void;
+}
+
+function toLLMToolCalls(calls: ParsedToolCall[]): LLMResponse['toolCalls'] {
+  return calls.map(call => ({
+    id: call.id ?? '',
+    type: 'function',
+    name: call.function.name,
+    arguments: call.function.arguments,
+  }));
+}
 
 export class OllamaProvider implements LLMProvider {
   public readonly name = 'ollama';
@@ -45,18 +66,18 @@ export class OllamaProvider implements LLMProvider {
 
   public async generateCode(
     prompt: string,
-    options: Record<string, unknown> = {}
+    options: GenerateCodeOptions = {}
   ): Promise<LLMResponse> {
-    const model = (options.model as string) ?? this.config.defaultModel;
-    const messages = [
-      { role: 'system', content: generateContextualSystemPrompt() },
+    const model = options.model ?? this.config.defaultModel;
+    const messages: OllamaMessage[] = [
+      { role: 'system', content: generateContextualSystemPrompt([]) },
       { role: 'user', content: prompt },
     ];
 
     const request: OllamaRequest = {
       model,
       messages,
-      stream: typeof (options as any).onStreamingToken === 'function',
+      stream: typeof options.onStreamingToken === 'function',
     };
 
     const controller = new AbortController();
@@ -64,15 +85,21 @@ export class OllamaProvider implements LLMProvider {
 
     try {
       const response = await this.http.post('/api/chat', request, controller.signal);
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '');
+        throw new Error(`Ollama API request failed with status ${response.status}: ${errorText}`);
+      }
+
       let text = '';
-      let metadata = {} as Record<string, unknown>;
-      let toolCalls = [] as Array<{ id?: string; function: { name: string; arguments: string } }>;
+      let metadata: Record<string, unknown> = {};
+      let toolCalls: LLMResponse['toolCalls'] = [];
 
       if (request.stream) {
-        const result = await handleStreaming(response, (options as any).onStreamingToken as any);
+        const onToken = options.onStreamingToken!;
+        const result = await handleStreaming(response, onToken);
         text = result.text;
-        metadata = result.metadata as Record<string, unknown>;
-        toolCalls = extractToolCalls(result.toolCalls) as any;
+        metadata = result.metadata;
+        toolCalls = toLLMToolCalls(extractToolCalls(result.toolCalls));
       } else {
         const json = await parseResponse(response);
         text = json.message?.content ?? json.response ?? '';
@@ -83,7 +110,7 @@ export class OllamaProvider implements LLMProvider {
           evalCount: json.eval_count,
           context: json.context,
         };
-        toolCalls = extractToolCalls(json.message?.tool_calls);
+        toolCalls = toLLMToolCalls(extractToolCalls(json.message?.tool_calls));
       }
 
       return {
@@ -92,7 +119,7 @@ export class OllamaProvider implements LLMProvider {
         responseTime: 0,
         model,
         provider: this.name,
-        toolCalls: toolCalls as any,
+        toolCalls,
         metadata,
       };
     } catch (err) {
@@ -102,6 +129,24 @@ export class OllamaProvider implements LLMProvider {
     } finally {
       clearTimeout(timeout);
     }
+  }
+
+  public async request(request: unknown): Promise<LLMResponse> {
+    const req = request as OllamaRequest;
+    if (req.prompt) {
+      return this.generateCode(req.prompt, {
+        model: req.model,
+        onStreamingToken: req.onStreamingToken,
+      });
+    }
+    if (req.messages) {
+      const userContent = req.messages.find(m => m.role === 'user')?.content ?? '';
+      return this.generateCode(userContent, {
+        model: req.model,
+        onStreamingToken: req.onStreamingToken,
+      });
+    }
+    throw new Error('Invalid request: missing prompt or messages');
   }
 
   public getCapabilities(): LLMCapabilities {

--- a/src/providers/hybrid/ollama-provider.ts
+++ b/src/providers/hybrid/ollama-provider.ts
@@ -70,7 +70,7 @@ export class OllamaProvider implements LLMProvider {
   ): Promise<LLMResponse> {
     const model = options.model ?? this.config.defaultModel;
     const messages: OllamaMessage[] = [
-      { role: 'system', content: generateContextualSystemPrompt([]) },
+      { role: 'system', content: generateContextualSystemPrompt() },
       { role: 'user', content: prompt },
     ];
 

--- a/src/providers/hybrid/ollama-streaming-handler.ts
+++ b/src/providers/hybrid/ollama-streaming-handler.ts
@@ -10,39 +10,49 @@ export async function handleStreaming(
   }
 
   const decoder = new TextDecoder();
+  let buffer = '';
   let accumulated = '';
   let metadata: OllamaStreamingMetadata = {};
   let toolCalls: OllamaToolCall[] = [];
 
+  const processLine = (line: string) => {
+    try {
+      const json = JSON.parse(line) as OllamaResponse;
+      if (json.message?.content) {
+        onToken(json.message.content, metadata);
+        accumulated += json.message.content;
+      }
+      if (json.message?.tool_calls) {
+        toolCalls = json.message.tool_calls;
+      }
+      metadata = {
+        model: json.model,
+        totalDuration: json.total_duration,
+        loadDuration: json.load_duration,
+        promptEvalCount: json.prompt_eval_count,
+        promptEvalDuration: json.prompt_eval_duration,
+        evalCount: json.eval_count,
+        evalDuration: json.eval_duration,
+        context: json.context,
+      };
+    } catch {
+      // ignore malformed lines
+    }
+  };
+
   while (true) {
     const { value, done } = await reader.read();
     if (done) break;
-    const chunk = decoder.decode(value, { stream: true });
-    const lines = chunk.split('\n').filter(Boolean);
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
     for (const line of lines) {
-      try {
-        const json = JSON.parse(line) as OllamaResponse;
-        if (json.message?.content) {
-          onToken(json.message.content, metadata);
-          accumulated += json.message.content;
-        }
-        if (json.message?.tool_calls) {
-          toolCalls = json.message.tool_calls;
-        }
-        metadata = {
-          model: json.model,
-          totalDuration: json.total_duration,
-          loadDuration: json.load_duration,
-          promptEvalCount: json.prompt_eval_count,
-          promptEvalDuration: json.prompt_eval_duration,
-          evalCount: json.eval_count,
-          evalDuration: json.eval_duration,
-          context: json.context,
-        };
-      } catch {
-        // ignore malformed lines
-      }
+      if (line) processLine(line);
     }
+  }
+
+  if (buffer) {
+    processLine(buffer);
   }
 
   return { text: accumulated, metadata, toolCalls };


### PR DESCRIPTION
## Summary
- surface non-OK Ollama API responses and map tool calls with strict types
- buffer partial streaming chunks for reliable token emission
- add configurable connection pool defaulting to 10 and depend on undici

## Testing
- `npm run lint:fix`
- `npm run typecheck`
- `npm test` *(fails: Cannot find module '../../../../src/core/agents/agent-communication-protocol.js' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf2b56600832da31e3a77c9ca1205