### PR TITLE
fix(production): expose access controls and preserve defaults

### DIFF
--- a/src/infrastructure/production/access-control-manager.ts
+++ b/src/infrastructure/production/access-control-manager.ts
@@ -14,7 +14,8 @@ export class AccessControlManager {
 
   public checkAccess(userId: string, permission: string): void {
     if (this.accessMap.size === 0) {
-      return;
+      logger.warn(`Access denied for user ${userId} attempting ${permission}: no permissions configured`);
+      throw new Error('Access denied: no permissions configured');
     }
     const perms = this.accessMap.get(userId);
     if (perms?.has(permission)) {

--- a/src/infrastructure/production/access-control-manager.ts
+++ b/src/infrastructure/production/access-control-manager.ts
@@ -4,18 +4,23 @@ export class AccessControlManager {
   private readonly accessMap: Map<string, Set<string>> = new Map();
 
   public grant(userId: string, permission: string): void {
-    if (!this.accessMap.has(userId)) {
-      this.accessMap.set(userId, new Set());
-    }
     const perms = this.accessMap.get(userId);
-    perms!.add(permission);
+    if (perms) {
+      perms.add(permission);
+    } else {
+      this.accessMap.set(userId, new Set([permission]));
+    }
   }
 
   public checkAccess(userId: string, permission: string): void {
-    const perms = this.accessMap.get(userId);
-    if (!perms || !perms.has(permission)) {
-      logger.warn(`Access denied for user ${userId} attempting ${permission}`);
-      throw new Error('Access denied');
+    if (this.accessMap.size === 0) {
+      return;
     }
+    const perms = this.accessMap.get(userId);
+    if (perms?.has(permission)) {
+      return;
+    }
+    logger.warn(`Access denied for user ${userId} attempting ${permission}`);
+    throw new Error('Access denied');
   }
 }

--- a/src/infrastructure/production/production-hardening-system.ts
+++ b/src/infrastructure/production/production-hardening-system.ts
@@ -54,7 +54,23 @@ export class ProductionHardeningSystem extends EventEmitter {
     config: Partial<ProductionHardeningConfig> = {}
   ): ProductionHardeningSystem {
     if (!this.instance) {
-      this.instance = new ProductionHardeningSystem({ ...defaultConfig, ...config });
+      const merged: ProductionHardeningConfig = {
+        security: {
+          rateLimiting: {
+            ...defaultConfig.security.rateLimiting,
+            ...(config.security?.rateLimiting ?? {}),
+          },
+          inputValidation: {
+            ...defaultConfig.security.inputValidation,
+            ...(config.security?.inputValidation ?? {}),
+          },
+          auditLogging: {
+            ...defaultConfig.security.auditLogging,
+            ...(config.security?.auditLogging ?? {}),
+          },
+        },
+      };
+      this.instance = new ProductionHardeningSystem(merged);
     }
     return this.instance;
   }
@@ -90,7 +106,7 @@ export class ProductionHardeningSystem extends EventEmitter {
     this.stats.totalOperations++;
     const n = this.stats.totalOperations;
     this.stats.averageResponseTime = (this.stats.averageResponseTime * (n - 1) + duration) / n;
-    this.stats.successRate = (this.stats.successRate * (n - 1) + 1) / n;
+    this.stats.successRate = (this.stats.successRate * (n - 1) + 100) / n;
   }
 
   private recordFailure(duration: number): void {

--- a/src/infrastructure/production/security-enforcer.ts
+++ b/src/infrastructure/production/security-enforcer.ts
@@ -14,7 +14,7 @@ export interface EnforcementContext {
 }
 
 export class SecurityEnforcer {
-  private readonly access = new AccessControlManager();
+  private readonly access: AccessControlManager;
   private readonly scanner = new VulnerabilityScanner();
   private readonly audit = new AuditLogger();
   private readonly compliance = new ComplianceChecker();
@@ -22,7 +22,12 @@ export class SecurityEnforcer {
   private readonly incident = new IncidentResponse();
   private readonly metrics = new SecurityMetrics();
 
-  public constructor(private readonly config: SecurityConfig) {}
+  public constructor(
+    private readonly config: SecurityConfig,
+    access?: AccessControlManager
+  ) {
+    this.access = access ?? new AccessControlManager();
+  }
 
   public async initialize(): Promise<void> {
     if (this.config.auditLogging.enabled) {
@@ -81,6 +86,10 @@ export class SecurityEnforcer {
 
   public async shutdown(): Promise<void> {
     // No resources to cleanup yet
+  }
+
+  public grantAccess(userId: string, permission: string): void {
+    this.access.grant(userId, permission);
   }
 
   public getMetrics(): SecurityMetrics {


### PR DESCRIPTION
## Summary
- allow injecting and configuring access control via SecurityEnforcer
- preserve nested security defaults when overriding hardening config
- track success rate as percentage and expose access grant API

## Testing
- `npm run lint:fix` (fails: Cannot find package '@eslint/js')
- `npx prettier src/infrastructure/production/security-enforcer.ts src/infrastructure/production/access-control-manager.ts src/infrastructure/production/production-hardening-system.ts -w`
- `npm run typecheck` (fails: Cannot find type definition file for 'jest')
- `npm test` (fails: Cannot find module 'jest/bin/jest.js')

------
https://chatgpt.com/codex/tasks/task_e_68bcf34236b0832d813eb2a4c9c719da