### PR TITLE
fix(orchestration): register plugin commands

### DIFF
--- a/src/application/services/unified-orchestration-service.ts
+++ b/src/application/services/unified-orchestration-service.ts
@@ -220,7 +220,12 @@ export class UnifiedOrchestrationService {
           name: Readonly<string>,
           handler: (...args: ReadonlyArray<unknown>) => unknown
         ): void => {
+          // Register with command bus for execution
           this.commandRegistry?.register(name, handler, { plugin: 'plugin' });
+
+          // Also expose via dependency resolver so executePluginCommand works
+          this.registerPlugin(name, handler);
+
           this.eventBus.emit('plugin:command_registered', { name });
         },
       });


### PR DESCRIPTION
## Summary
- ensure plugin manager registers commands with dependency resolver so plugin commands execute

## Testing
- `npm run lint:fix -- src/application/services/unified-orchestration-service.ts` *(fails: Cannot find package '@eslint/js')*
- `npm run format -- src/application/services/unified-orchestration-service.ts` *(fails: SyntaxError: Declaration or statement expected)*
- `npm run typecheck -- src/application/services/unified-orchestration-service.ts` *(fails: TS1005: ',' expected)*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68bcf3ea0f74832d9a9b0d0cfc75b2a3