### PR TITLE
fix(production): document explicit access control defaults

### DIFF
--- a/src/infrastructure/production/access-control-manager.ts
+++ b/src/infrastructure/production/access-control-manager.ts
@@ -1,34 +1,43 @@
 import { logger } from '../logging/logger.js';
 
+/**
+ * Options for configuring the AccessControlManager.
+ *
+ * Enabling `defaultAllow` will grant access when no permissions are
+ * configured. This weakens the security model and should be enabled only in
+ * controlled environments.
+ */
+export interface AccessControlOptions {
+  /** Allow all access when no permissions are registered */
+  defaultAllow?: boolean;
+}
+
 export class AccessControlManager {
   private readonly accessMap: Map<string, Set<string>> = new Map();
+  private readonly defaultAllow: boolean;
+
+  public constructor(options: AccessControlOptions = {}) {
+    this.defaultAllow = options.defaultAllow ?? false;
+  }
 
   public grant(userId: string, permission: string): void {
-
-    let perms = this.accessMap.get(userId);
-    if (!perms) {
-      perms = new Set();
-      this.accessMap.set(userId, perms);
-    }
-    perms.add(permission);
-
     const perms = this.accessMap.get(userId);
     if (perms) {
       perms.add(permission);
     } else {
       this.accessMap.set(userId, new Set([permission]));
     }
-
   }
 
   public checkAccess(userId: string, permission: string): void {
     if (this.accessMap.size === 0) {
-
-      return; // default allow when no permissions configured
-
-      logger.warn(`Access denied for user ${userId} attempting ${permission}: no permissions configured`);
+      if (this.defaultAllow) {
+        return;
+      }
+      logger.warn(
+        `Access denied for user ${userId} attempting ${permission}: no permissions configured`
+      );
       throw new Error('Access denied: no permissions configured');
-
     }
     const perms = this.accessMap.get(userId);
     if (perms?.has(permission)) {

--- a/src/infrastructure/production/production-hardening-system.ts
+++ b/src/infrastructure/production/production-hardening-system.ts
@@ -4,8 +4,8 @@ import { logger } from '../logging/logger.js';
 import type { ProductionHardeningConfig, ProductionStats } from './hardening-types.js';
 import { SecurityEnforcer } from './security-enforcer.js';
 
-function deepMerge<T extends Record<string, any>>(base: T, override: Partial<T>): T {
-  const result: Record<string, any> = { ...base };
+function deepMerge<T extends Record<string, unknown>>(base: T, override: Partial<T>): T {
+  const result: Record<string, unknown> = { ...base };
   for (const key of Object.keys(override)) {
     const baseVal = base[key as keyof T];
     const overrideVal = override[key as keyof Partial<T>];
@@ -76,7 +76,6 @@ export class ProductionHardeningSystem extends EventEmitter {
     config: Partial<ProductionHardeningConfig> = {}
   ): ProductionHardeningSystem {
     if (!this.instance) {
-
       this.instance = new ProductionHardeningSystem(deepMerge(defaultConfig, config));
 
       const merged: ProductionHardeningConfig = {
@@ -96,7 +95,6 @@ export class ProductionHardeningSystem extends EventEmitter {
         },
       };
       this.instance = new ProductionHardeningSystem(merged);
-
     }
     return this.instance;
   }
@@ -137,7 +135,6 @@ export class ProductionHardeningSystem extends EventEmitter {
     this.stats.successRate = (this.successfulOperations / n) * 100;
 
     this.stats.successRate = (this.stats.successRate * (n - 1) + 100) / n;
-
   }
 
   private recordFailure(duration: number): void {

--- a/src/infrastructure/production/security-enforcer.ts
+++ b/src/infrastructure/production/security-enforcer.ts
@@ -95,8 +95,4 @@ export class SecurityEnforcer {
   public getMetrics(): SecurityMetrics {
     return this.metrics;
   }
-
-  public grantAccess(userId: string, permission: string): void {
-    this.access.grant(userId, permission);
-  }
 }


### PR DESCRIPTION
## Summary
- expose `defaultAllow` option for AccessControlManager so permissive behavior is opt-in
- improve deep merge typing to avoid `any` assertions
- clean up duplicate access helper in SecurityEnforcer

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: SyntaxError in existing source files)*
- `npm run typecheck` *(fails: TypeScript errors in unrelated files)*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68bd5ef8482c832dbf1ecccdb82b1b4b