### PR TITLE
fix(production): return success on access check

### DIFF
--- a/src/infrastructure/production/access-control-manager.ts
+++ b/src/infrastructure/production/access-control-manager.ts
@@ -12,7 +12,7 @@ export class AccessControlManager {
     }
   }
 
-  public checkAccess(userId: string, permission: string): void {
+  public checkAccess(userId: string, permission: string): boolean {
     if (this.accessMap.size === 0) {
       logger.warn(
         `Access denied for user ${userId} attempting ${permission}: no permissions configured`
@@ -24,5 +24,7 @@ export class AccessControlManager {
       logger.warn(`Access denied for user ${userId} attempting ${permission}`);
       throw new Error('Access denied');
     }
+    logger.info(`Access granted for user ${userId} to ${permission}`);
+    return true;
   }
 }


### PR DESCRIPTION
## Summary
- add explicit success path to access check

## Testing
- `npm run lint:fix` (fails: Cannot find module 'eslint')
- `npm run format` (fails: SyntaxError in unified-orchestration-service.ts)
- `npm run typecheck` (fails: multiple TS errors in unified-orchestration-service.ts)
- `npm test` (fails: Cannot find module 'typescript')

------
https://chatgpt.com/codex/tasks/task_e_68bd62d5d244832d93c09b783ddd0fbc