### PR TITLE
fix(cli): refine code generation detection

### DIFF
--- a/tests/unit/use-case-router.test.ts
+++ b/tests/unit/use-case-router.test.ts
@@ -3,15 +3,20 @@ import { UseCaseRouter } from '../../src/application/cli/use-case-router.js';
 describe('UseCaseRouter isCodeGenerationRequest', () => {
   const router = new UseCaseRouter();
 
+  const callIsCodeGenerationRequest = (prompt: string): boolean =>
+    (
+      router as unknown as {
+        isCodeGenerationRequest: (prompt: string) => boolean;
+      }
+    ).isCodeGenerationRequest(prompt);
+
   it('returns false for data file creation requests', () => {
     const prompt = 'Create JSON file with sample data';
-    // @ts-expect-error accessing private method for testing
-    expect((router as any).isCodeGenerationRequest(prompt)).toBe(false);
+    expect(callIsCodeGenerationRequest(prompt)).toBe(false);
   });
 
   it('returns true for code file scaffolding', () => {
     const prompt = 'Create module user-service.ts with a class stub';
-    // @ts-expect-error accessing private method for testing
-    expect((router as any).isCodeGenerationRequest(prompt)).toBe(true);
+    expect(callIsCodeGenerationRequest(prompt)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- replace `@ts-expect-error` directives with a typed helper for calling the router's private `isCodeGenerationRequest`

## Testing
- `npx prettier tests/unit/use-case-router.test.ts --write`
- `npm run lint:fix tests/unit/use-case-router.test.ts` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest', 'node')*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68c468536e0c832d975f244dc73691cf