### PR TITLE
fix(rust-executor): restore FreeBSD binding resolution

### DIFF
--- a/rust-executor/index.js
+++ b/rust-executor/index.js
@@ -34,6 +34,7 @@ const PLATFORM_ARCH_MAP = {
   'linux-riscv64-gnu': 'linux-riscv64-gnu',
   'linux-riscv64-musl': 'linux-riscv64-musl',
   'linux-s390x': 'linux-s390x-gnu',
+  'freebsd-x64': 'freebsd-x64',
 };
 
 function resolveKey() {


### PR DESCRIPTION
## Summary
- add freebsd-x64 mapping to native binding loader

## Testing
- `npx eslint rust-executor/index.js --fix`
- `npx prettier rust-executor/index.js --write`
- `npm run typecheck`
- `npm test` *(fails: SyntaxError: Unexpected token 'export')*

------
https://chatgpt.com/codex/tasks/task_e_68c467bc2c64832db5f29a4448f71b72