### PR TITLE
fix(tools): include core filesystem tools and log exclusions

### DIFF
--- a/src/infrastructure/tools/domain-aware-tool-orchestrator.ts
+++ b/src/infrastructure/tools/domain-aware-tool-orchestrator.ts
@@ -433,11 +433,43 @@ export class DomainAwareToolOrchestrator {
       ]);
     }
 
+    // Ensure core filesystem and git tools are always available
+    const essentialTools = new Set([
+      'file_read',
+      'file_write',
+      'grep_search',
+      'glob_search',
+      'bash_run',
+      'filesystem_read_file',
+      'filesystem_write_file',
+      'filesystem_list_directory',
+      'filesystem_get_stats',
+      'filesystem_file_stats',
+      'filesystem_find_files',
+      'mcp_read_file',
+      'mcp_write_file',
+      'mcp_list_directory',
+      'mcp_execute_command',
+    ]);
+    allAvailableTools.forEach(tool => {
+      const toolName: string = tool.function?.name ?? tool.name;
+      if (essentialTools.has(toolName)) {
+        selectedToolNames.add(toolName);
+      }
+    });
+
     // Filter available tools to match selected tool names
     const selectedTools = allAvailableTools.filter(tool => {
       const toolName: string = tool.function?.name ?? tool.name;
       return selectedToolNames.has(toolName);
     });
+
+    const excludedToolNames = allAvailableTools
+      .map(tool => tool.function?.name ?? tool.name)
+      .filter(name => !selectedToolNames.has(name));
+    if (excludedToolNames.length > 0) {
+      this.logger.debug('Excluded tools after domain filtering', { excludedToolNames });
+    }
 
     const reasoning =
       `Domain: ${analysis.primaryDomain} (${(analysis.confidence * 100).toFixed(0)}% confidence), ` +

--- a/tests/unit/infrastructure/tools/domain-aware-tool-orchestrator.test.ts
+++ b/tests/unit/infrastructure/tools/domain-aware-tool-orchestrator.test.ts
@@ -1,0 +1,21 @@
+import { DomainAwareToolOrchestrator } from '../../../../src/infrastructure/tools/domain-aware-tool-orchestrator.js';
+
+describe('DomainAwareToolOrchestrator', () => {
+  it('includes essential filesystem tools regardless of domain confidence', () => {
+    const orchestrator = new DomainAwareToolOrchestrator();
+    const mockTools = [
+      { name: 'file_read' },
+      { name: 'file_write' },
+      { name: 'mcp_execute_command' },
+    ];
+
+    const result = orchestrator.getToolsForPrompt('research the history of compilers', mockTools);
+    const selectedNames = result.tools.map(t => t.name);
+
+    expect(result.analysis.primaryDomain).toBe('research');
+    expect(result.analysis.confidence).toBeGreaterThan(0.7);
+    expect(selectedNames).toEqual(
+      expect.arrayContaining(['file_read', 'file_write', 'mcp_execute_command'])
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- always include filesystem and git basics in domain-aware tool selection
- log excluded tools for easier debugging
- add unit test covering essential tool inclusion

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest')*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68c4f48f1738832db5805fc84cfffb45