### PR TITLE
refactor: centralize rust bridge initialization

### DIFF
--- a/src/infrastructure/execution/rust/initialize-rust-bridge.ts
+++ b/src/infrastructure/execution/rust/initialize-rust-bridge.ts
@@ -1,0 +1,11 @@
+import { RustBridgeManager, type BridgeConfiguration } from './rust-bridge-manager.js';
+
+export async function initializeRustBridge(
+  config: Partial<BridgeConfiguration> = {}
+): Promise<RustBridgeManager> {
+  const ok = await RustBridgeManager.initializeInstance(config);
+  if (!ok) {
+    throw new Error('Failed to initialize Rust bridge');
+  }
+  return RustBridgeManager.getInstance();
+}

--- a/src/infrastructure/execution/rust/rust-bridge-manager.ts
+++ b/src/infrastructure/execution/rust/rust-bridge-manager.ts
@@ -30,7 +30,7 @@ export interface BridgeHealth {
 export class RustBridgeManager {
   private static instance: RustBridgeManager | null = null;
   private static initializationPromise: Promise<boolean> | null = null;
-  
+
   private config: BridgeConfiguration;
   private rustModule: any = null;
   private health: BridgeHealth;
@@ -67,7 +67,9 @@ export class RustBridgeManager {
    * Initialize the singleton instance (idempotent)
    * Returns the same promise if initialization is already in progress
    */
-  public static async initializeInstance(config: Partial<BridgeConfiguration> = {}): Promise<boolean> {
+  public static async initializeInstance(
+    config: Partial<BridgeConfiguration> = {}
+  ): Promise<boolean> {
     if (!RustBridgeManager.initializationPromise) {
       const instance = RustBridgeManager.getInstance(config);
       RustBridgeManager.initializationPromise = instance.initialize();
@@ -80,6 +82,11 @@ export class RustBridgeManager {
    */
   async initialize(): Promise<boolean> {
     try {
+      if (this.rustModule) {
+        logger.debug('Rust bridge already initialized');
+        return true;
+      }
+
       logger.info('Initializing Rust bridge...', {
         modulePath: this.config.modulePath,
         timeout: this.config.initializationTimeout,

--- a/src/infrastructure/rust/rust-provider-client.ts
+++ b/src/infrastructure/rust/rust-provider-client.ts
@@ -7,6 +7,7 @@
 
 import { logger } from '../../infrastructure/logging/logger.js';
 import { RustBridgeManager } from '../execution/rust/rust-bridge-manager.js';
+import { initializeRustBridge } from '../execution/rust/initialize-rust-bridge.js';
 import { toErrorOrUndefined, toReadonlyRecord } from '../../utils/type-guards.js';
 
 export interface RustProviderConfig {
@@ -88,10 +89,7 @@ export class RustProviderClient {
         capabilities: this.config.capabilities,
       });
 
-      const success = await this.bridgeManager.initialize();
-      if (!success) {
-        throw new Error('Failed to initialize Rust bridge');
-      }
+      await initializeRustBridge();
     } catch (error) {
       logger.error('Error initializing Rust provider client:', toErrorOrUndefined(error));
       throw error;


### PR DESCRIPTION
## Summary
- add initializeRustBridge helper to expose a shared RustBridgeManager instance
- guard RustBridgeManager.initialize against repeated loads
- refactor bridge adapter and provider client to use shared initializer

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest', 'node')*
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68c4f53427f8832dbbbb941ed7d271d0