### PR TITLE
refactor(cli): modularize run-cli orchestration

### DIFF
--- a/src/application/cli/command-dispatcher.ts
+++ b/src/application/cli/command-dispatcher.ts
@@ -1,0 +1,38 @@
+import { showHelp, showStatus } from './help.js';
+import { bootstrapToolRegistration } from './bootstrap/tool-registration.js';
+import type { ParsedCLIArgs } from './args-parser.js';
+
+export async function dispatchCommand(parsed: ParsedCLIArgs): Promise<boolean> {
+  switch (parsed.command) {
+    case 'version': {
+      const { getVersion } = await import('../../utils/version.js');
+      console.log(`CodeCrucible Synth v${await getVersion()} (Unified Architecture)`);
+      return true;
+    }
+    case 'help': {
+      showHelp();
+      return true;
+    }
+    case 'status': {
+      await showStatus();
+      return true;
+    }
+    case 'models': {
+      const { ModelsCommand } = await import('./models-command.js');
+      const modelsCommand = new ModelsCommand();
+      await modelsCommand.execute(parsed.options);
+      return true;
+    }
+    case 'tools': {
+      await bootstrapToolRegistration();
+      const { ToolsCommand } = await import('./tools-command.js');
+      const toolsCommand = new ToolsCommand();
+      await toolsCommand.execute(parsed.options);
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+
+export default dispatchCommand;

--- a/src/application/cli/initialize-cli.ts
+++ b/src/application/cli/initialize-cli.ts
@@ -1,0 +1,8 @@
+import { CLIOptions } from '../interfaces/unified-cli.js';
+import initialize from '../bootstrap/initialize.js';
+
+export async function initializeCLI(cliOptions: Readonly<CLIOptions>, isInteractive: boolean) {
+  return initialize(cliOptions as CLIOptions, isInteractive);
+}
+
+export default initializeCLI;

--- a/src/application/cli/parse-arguments.ts
+++ b/src/application/cli/parse-arguments.ts
@@ -1,0 +1,7 @@
+import parseCLIArgs, { ParsedCLIArgs } from './args-parser.js';
+
+export function parseArguments(rawArgs: readonly string[]): ParsedCLIArgs {
+  return parseCLIArgs(rawArgs);
+}
+
+export default parseArguments;

--- a/src/application/cli/setup-cleanup.ts
+++ b/src/application/cli/setup-cleanup.ts
@@ -1,0 +1,32 @@
+import { logger } from '../../infrastructure/logging/logger.js';
+
+export interface Disposable {
+  dispose(): Promise<void>;
+}
+
+export interface Shutdownable {
+  shutdown(): void;
+}
+
+export function setupCleanup(cli: Shutdownable, serviceFactory: Disposable) {
+  let cleanedUp = false;
+  const cleanup = async (): Promise<void> => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    logger.info('Application shutdown initiated');
+    console.log('\n🔻 Shutting down gracefully...');
+    cli.shutdown();
+    await serviceFactory.dispose();
+  };
+
+  process.on('SIGINT', () => {
+    void cleanup();
+  });
+  process.on('SIGTERM', () => {
+    void cleanup();
+  });
+
+  return cleanup;
+}
+
+export default setupCleanup;

--- a/tests/integration/application/cli/run-cli.integration.test.ts
+++ b/tests/integration/application/cli/run-cli.integration.test.ts
@@ -1,0 +1,43 @@
+jest.mock('../../../src/application/cli/parse-arguments.js', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ command: 'run', args: ['x'] })),
+}));
+
+jest.mock('../../../src/application/cli/command-dispatcher.js', () => ({
+  __esModule: true,
+  default: jest.fn(async () => false),
+}));
+
+const runMock = jest.fn(async () => {});
+const cleanupMock = jest.fn(async () => {});
+
+jest.mock('../../../src/application/cli/initialize-cli.js', () => ({
+  __esModule: true,
+  default: jest.fn(async () => ({
+    cli: { run: runMock, shutdown: jest.fn() },
+    serviceFactory: { dispose: jest.fn(async () => {}) },
+  })),
+}));
+
+jest.mock('../../../src/application/cli/setup-cleanup.js', () => ({
+  __esModule: true,
+  default: jest.fn(() => cleanupMock),
+}));
+
+import runCLI from '../../../src/application/cli/run-cli.js';
+import parseArguments from '../../../src/application/cli/parse-arguments.js';
+import dispatchCommand from '../../../src/application/cli/command-dispatcher.js';
+import initializeCLI from '../../../src/application/cli/initialize-cli.js';
+import setupCleanup from '../../../src/application/cli/setup-cleanup.js';
+
+describe('runCLI integration', () => {
+  it('composes parsing, dispatch, initialization, and cleanup', async () => {
+    await runCLI(['x'], {} as any, false);
+    expect(parseArguments).toHaveBeenCalledWith(['x']);
+    expect(dispatchCommand).toHaveBeenCalled();
+    expect(initializeCLI).toHaveBeenCalled();
+    expect(runMock).toHaveBeenCalledWith(['x']);
+    expect(setupCleanup).toHaveBeenCalled();
+    expect(cleanupMock).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/application/cli/command-dispatcher.test.ts
+++ b/tests/unit/application/cli/command-dispatcher.test.ts
@@ -1,0 +1,26 @@
+jest.mock('../../../src/application/cli/help.js', () => ({
+  __esModule: true,
+  showHelp: jest.fn(),
+  showStatus: jest.fn(),
+}));
+
+jest.mock('../../../src/application/cli/bootstrap/tool-registration.js', () => ({
+  __esModule: true,
+  bootstrapToolRegistration: jest.fn(),
+}));
+
+import dispatchCommand from '../../../src/application/cli/command-dispatcher.js';
+import { showHelp } from '../../../src/application/cli/help.js';
+
+describe('dispatchCommand', () => {
+  it('handles help command', async () => {
+    const handled = await dispatchCommand({ command: 'help' } as any);
+    expect(handled).toBe(true);
+    expect(showHelp).toHaveBeenCalled();
+  });
+
+  it('returns false for run command', async () => {
+    const handled = await dispatchCommand({ command: 'run', args: [] });
+    expect(handled).toBe(false);
+  });
+});

--- a/tests/unit/application/cli/initialize-cli.test.ts
+++ b/tests/unit/application/cli/initialize-cli.test.ts
@@ -1,0 +1,16 @@
+jest.mock('../../../src/application/bootstrap/initialize.js', () => ({
+  __esModule: true,
+  default: jest.fn(async () => ({ cli: 'cli', serviceFactory: 'sf' })),
+}));
+
+import initializeCLI from '../../../src/application/cli/initialize-cli.js';
+import initialize from '../../../src/application/bootstrap/initialize.js';
+
+describe('initializeCLI', () => {
+  it('calls initialize with provided options', async () => {
+    const options = {} as any;
+    const result = await initializeCLI(options, true);
+    expect(initialize).toHaveBeenCalledWith(options, true);
+    expect(result).toEqual({ cli: 'cli', serviceFactory: 'sf' });
+  });
+});

--- a/tests/unit/application/cli/parse-arguments.test.ts
+++ b/tests/unit/application/cli/parse-arguments.test.ts
@@ -1,0 +1,15 @@
+jest.mock('../../../src/application/cli/args-parser.js', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ command: 'run', args: [] })),
+}));
+
+import parseArguments from '../../../src/application/cli/parse-arguments.js';
+import parseCLIArgs from '../../../src/application/cli/args-parser.js';
+
+describe('parseArguments', () => {
+  it('delegates to parseCLIArgs', () => {
+    const result = parseArguments(['a']);
+    expect(parseCLIArgs).toHaveBeenCalledWith(['a']);
+    expect(result).toEqual({ command: 'run', args: [] });
+  });
+});

--- a/tests/unit/application/cli/setup-cleanup.test.ts
+++ b/tests/unit/application/cli/setup-cleanup.test.ts
@@ -1,0 +1,21 @@
+import setupCleanup from '../../../src/application/cli/setup-cleanup.js';
+
+describe('setupCleanup', () => {
+  it('registers handlers and cleans up once', async () => {
+    const cli = { shutdown: jest.fn() };
+    const serviceFactory = { dispose: jest.fn(async () => {}) };
+    const onSpy = jest.spyOn(process, 'on');
+
+    const cleanup = setupCleanup(cli, serviceFactory);
+    expect(onSpy).toHaveBeenCalledWith('SIGINT', expect.any(Function));
+    expect(onSpy).toHaveBeenCalledWith('SIGTERM', expect.any(Function));
+
+    await cleanup();
+    await cleanup();
+
+    expect(cli.shutdown).toHaveBeenCalledTimes(1);
+    expect(serviceFactory.dispose).toHaveBeenCalledTimes(1);
+
+    onSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- modularize CLI flow into argument parsing, command dispatch, initialization, and cleanup helpers
- add orchestration wrapper and unit/integration tests

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run format`
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest')*
- `npm test` *(fails: Cannot find module 'jest')*


------
https://chatgpt.com/codex/tasks/task_e_68c4f54ff550832d8065f5ed4d44dd43