### PR TITLE
fix: reset rust bridge initialization after failure or shutdown

### DIFF
--- a/src/infrastructure/execution/rust/rust-bridge-manager.ts
+++ b/src/infrastructure/execution/rust/rust-bridge-manager.ts
@@ -72,7 +72,10 @@ export class RustBridgeManager {
   ): Promise<boolean> {
     if (!RustBridgeManager.initializationPromise) {
       const instance = RustBridgeManager.getInstance(config);
-      RustBridgeManager.initializationPromise = instance.initialize();
+      RustBridgeManager.initializationPromise = instance.initialize().catch(error => {
+        RustBridgeManager.initializationPromise = null;
+        throw error;
+      });
     }
     return RustBridgeManager.initializationPromise;
   }
@@ -232,6 +235,9 @@ export class RustBridgeManager {
 
       this.rustModule = null;
       this.health.status = 'failed';
+
+      // Allow future calls to initializeInstance to reinitialize the bridge
+      RustBridgeManager.initializationPromise = null;
 
       logger.info('Rust bridge shut down successfully');
     } catch (error) {


### PR DESCRIPTION
## Summary
- reset `initializationPromise` if `initialize()` fails so retries can run
- clear cached promise on `shutdown()` to allow reinitialization after cleanup

## Testing
- `npm run lint:fix` *(fails: Cannot find package '@eslint/js')*
- `npm run format`
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest', 'node')*
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*


------
https://chatgpt.com/codex/tasks/task_e_68c4f781ed88832d92dc5b8d444623db